### PR TITLE
Bump lower Dart SDK constraints to 3.0

### DIFF
--- a/.github/workflows/windows_ai.yml
+++ b/.github/workflows/windows_ai.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_applicationmodel.yml
+++ b/.github/workflows/windows_applicationmodel.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_data.yml
+++ b/.github/workflows/windows_data.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_devices.yml
+++ b/.github/workflows/windows_devices.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_foundation.yml
+++ b/.github/workflows/windows_foundation.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_gaming.yml
+++ b/.github/workflows/windows_gaming.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_globalization.yml
+++ b/.github/workflows/windows_globalization.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_graphics.yml
+++ b/.github/workflows/windows_graphics.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_management.yml
+++ b/.github/workflows/windows_management.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_media.yml
+++ b/.github/workflows/windows_media.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: lib test

--- a/.github/workflows/windows_networking.yml
+++ b/.github/workflows/windows_networking.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_perception.yml
+++ b/.github/workflows/windows_perception.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_security.yml
+++ b/.github/workflows/windows_security.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_services.yml
+++ b/.github/workflows/windows_services.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_storage.yml
+++ b/.github/workflows/windows_storage.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_system.yml
+++ b/.github/workflows/windows_system.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_ui.yml
+++ b/.github/workflows/windows_ui.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/windows_web.yml
+++ b/.github/workflows/windows_web.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: example lib test

--- a/.github/workflows/winrtgen.yml
+++ b/.github/workflows/winrtgen.yml
@@ -26,12 +26,13 @@ jobs:
         include:
           - os: windows-latest
             sdk: main
-          - os: windows-2022
-            sdk: beta
-          - os: windows-2019
-            sdk: stable
-          - os: ubuntu-latest
-            sdk: stable
+          # TODO: Enable after Dart 3.0 is released.
+          # - os: windows-2022
+          #   sdk: beta
+          # - os: windows-2019
+          #   sdk: stable
+          # - os: ubuntu-latest
+          #   sdk: stable
     uses: ./.github/workflows/dart_package.yml
     with:
       analyze_directories: bin example lib test

--- a/packages/windows_ai/pubspec.yaml
+++ b/packages/windows_ai/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -24,4 +24,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_applicationmodel/pubspec.yaml
+++ b/packages/windows_applicationmodel/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -24,4 +24,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_data/pubspec.yaml
+++ b/packages/windows_data/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -25,4 +25,4 @@ dependencies:
     path: ../windows_storage
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_devices/pubspec.yaml
+++ b/packages/windows_devices/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -33,4 +33,4 @@ dependencies:
     path: ../windows_ui
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_foundation/lib/src/internal/native_structs.g.dart
+++ b/packages/windows_foundation/lib/src/internal/native_structs.g.dart
@@ -8,7 +8,7 @@
 
 import 'dart:ffi';
 
-class NativeBasicGeoposition extends Struct {
+final class NativeBasicGeoposition extends Struct {
   @Double()
   external double latitude;
 
@@ -19,7 +19,7 @@ class NativeBasicGeoposition extends Struct {
   external double altitude;
 }
 
-class NativeColor extends Struct {
+final class NativeColor extends Struct {
   @Uint8()
   external int a;
 
@@ -33,7 +33,7 @@ class NativeColor extends Struct {
   external int b;
 }
 
-class NativeGamepadReading extends Struct {
+final class NativeGamepadReading extends Struct {
   @Uint64()
   external int timestamp;
 
@@ -59,7 +59,7 @@ class NativeGamepadReading extends Struct {
   external double rightThumbstickY;
 }
 
-class NativeGamepadVibration extends Struct {
+final class NativeGamepadVibration extends Struct {
   @Double()
   external double leftMotor;
 
@@ -73,7 +73,7 @@ class NativeGamepadVibration extends Struct {
   external double rightTrigger;
 }
 
-class NativeMatrix3x2 extends Struct {
+final class NativeMatrix3x2 extends Struct {
   @Float()
   external double m11;
 
@@ -93,7 +93,7 @@ class NativeMatrix3x2 extends Struct {
   external double m32;
 }
 
-class NativeMatrix4x4 extends Struct {
+final class NativeMatrix4x4 extends Struct {
   @Float()
   external double m11;
 
@@ -143,7 +143,7 @@ class NativeMatrix4x4 extends Struct {
   external double m44;
 }
 
-class NativeNetworkUsageStates extends Struct {
+final class NativeNetworkUsageStates extends Struct {
   @Int32()
   external int roaming;
 
@@ -151,14 +151,14 @@ class NativeNetworkUsageStates extends Struct {
   external int shared;
 }
 
-class NativePlane extends Struct {
+final class NativePlane extends Struct {
   external NativeVector3 normal;
 
   @Float()
   external double d;
 }
 
-class NativePoint extends Struct {
+final class NativePoint extends Struct {
   @Float()
   external double x;
 
@@ -166,7 +166,7 @@ class NativePoint extends Struct {
   external double y;
 }
 
-class NativeQuaternion extends Struct {
+final class NativeQuaternion extends Struct {
   @Float()
   external double x;
 
@@ -180,7 +180,7 @@ class NativeQuaternion extends Struct {
   external double w;
 }
 
-class NativeRational extends Struct {
+final class NativeRational extends Struct {
   @Uint32()
   external int numerator;
 
@@ -188,7 +188,7 @@ class NativeRational extends Struct {
   external int denominator;
 }
 
-class NativeRect extends Struct {
+final class NativeRect extends Struct {
   @Float()
   external double x;
 
@@ -202,7 +202,7 @@ class NativeRect extends Struct {
   external double height;
 }
 
-class NativeSize extends Struct {
+final class NativeSize extends Struct {
   @Float()
   external double width;
 
@@ -210,7 +210,7 @@ class NativeSize extends Struct {
   external double height;
 }
 
-class NativeSortEntry extends Struct {
+final class NativeSortEntry extends Struct {
   @IntPtr()
   external int propertyName;
 
@@ -218,7 +218,7 @@ class NativeSortEntry extends Struct {
   external bool ascendingOrder;
 }
 
-class NativeTextSegment extends Struct {
+final class NativeTextSegment extends Struct {
   @Uint32()
   external int startPosition;
 
@@ -226,7 +226,7 @@ class NativeTextSegment extends Struct {
   external int length;
 }
 
-class NativeVector2 extends Struct {
+final class NativeVector2 extends Struct {
   @Float()
   external double x;
 
@@ -234,7 +234,7 @@ class NativeVector2 extends Struct {
   external double y;
 }
 
-class NativeVector3 extends Struct {
+final class NativeVector3 extends Struct {
   @Float()
   external double x;
 
@@ -245,7 +245,7 @@ class NativeVector3 extends Struct {
   external double z;
 }
 
-class NativeVector4 extends Struct {
+final class NativeVector4 extends Struct {
   @Float()
   external double x;
 

--- a/packages/windows_foundation/pubspec.yaml
+++ b/packages/windows_foundation/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -24,4 +24,4 @@ dependencies:
     path: ../windows_media
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_gaming/pubspec.yaml
+++ b/packages/windows_gaming/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -27,4 +27,4 @@ dependencies:
     path: ../windows_system
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_globalization/pubspec.yaml
+++ b/packages/windows_globalization/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -24,4 +24,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_graphics/pubspec.yaml
+++ b/packages/windows_graphics/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -23,4 +23,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_management/pubspec.yaml
+++ b/packages/windows_management/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -23,4 +23,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_media/pubspec.yaml
+++ b/packages/windows_media/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -24,4 +24,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_networking/pubspec.yaml
+++ b/packages/windows_networking/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -27,4 +27,4 @@ dependencies:
     path: ../windows_storage
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_perception/pubspec.yaml
+++ b/packages/windows_perception/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -25,4 +25,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_security/pubspec.yaml
+++ b/packages/windows_security/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -23,4 +23,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_services/pubspec.yaml
+++ b/packages/windows_services/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -23,4 +23,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_storage/pubspec.yaml
+++ b/packages/windows_storage/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -28,4 +28,4 @@ dependencies:
     path: ../windows_system
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_system/pubspec.yaml
+++ b/packages/windows_system/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -24,4 +24,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_ui/pubspec.yaml
+++ b/packages/windows_ui/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -28,4 +28,4 @@ dependencies:
     path: ../windows_system
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/windows_web/pubspec.yaml
+++ b/packages/windows_web/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -23,4 +23,4 @@ dependencies:
     path: ../windows_foundation
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/winrtgen/lib/src/projections/struct.dart
+++ b/packages/winrtgen/lib/src/projections/struct.dart
@@ -73,7 +73,7 @@ class NativeStructProjection {
 
   String get classHeader => [
         if (isDeprecated) typeDef.deprecatedAnnotation,
-        'class $structName extends Struct'
+        'final class $structName extends Struct'
       ].join('\n');
 
   List<StructFieldProjection> get fieldProjections =>

--- a/packages/winrtgen/pubspec.yaml
+++ b/packages/winrtgen/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/dart-windows/dartwinrt/issues?q=is%3Aopen+is%3
 publish_to: none # TODO: Remove this
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 # Declare that this package only works on Windows.
 platforms:
@@ -50,4 +50,4 @@ dependency_overrides:
 
 dev_dependencies:
   # Running the test suite.
-  test: ^1.22.1
+  test: ^1.24.1

--- a/packages/winrtgen/test/projections/struct_test.dart
+++ b/packages/winrtgen/test/projections/struct_test.dart
@@ -52,7 +52,7 @@ void main() {
 
     test('has correct class header', () {
       expect(rectProjection.classHeader,
-          equals('class NativeRect extends Struct'));
+          equals('final class NativeRect extends Struct'));
     });
 
     test('has correct number of fields', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dartwinrt_workspace
 
 environment:
-  sdk: '^2.19.4'
+  sdk: '^3.0.0-0'
 
 dev_dependencies:
   melos: ^3.0.0-dev.0


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

- Bumps lower Dart SDK constraints to 3.0
- Marks generated native structs as `final`
- Updates workflows to only use the `main` branch of the Dart SDK

## Related Issue

Part of #141

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
