### PR TITLE
Support projection of `IMapView` parameters

### DIFF
--- a/packages/winrtgen/lib/src/projections/parameter.dart
+++ b/packages/winrtgen/lib/src/projections/parameter.dart
@@ -57,6 +57,7 @@ abstract class ParameterProjection {
         GenericObjectListParameterProjection(param),
       ProjectionType.guid => GuidParameterProjection(param),
       ProjectionType.guidList => GuidListParameterProjection(param),
+      ProjectionType.mapView ||
       ProjectionType.object ||
       ProjectionType.vectorView =>
         ObjectParameterProjection(param),

--- a/packages/winrtgen/lib/src/projections/type.dart
+++ b/packages/winrtgen/lib/src/projections/type.dart
@@ -192,7 +192,8 @@ final class TypeProjection {
   TypeTuple unwrapReferenceType() {
     final typeArg = dereferenceType(typeIdentifier);
     return switch (typeArg.baseType) {
-      BaseType.classTypeModifier =>
+      BaseType.classTypeModifier ||
+      BaseType.genericTypeModifier =>
         const TypeTuple('Pointer<COMObject>', 'Pointer<COMObject>'),
       // This form is used in WinRT methods when the caller receives an array
       // that was allocated by the method. In this style, the array size

--- a/packages/winrtgen/test/projections/parameter_test.dart
+++ b/packages/winrtgen/test/projections/parameter_test.dart
@@ -138,6 +138,18 @@ void main() {
       expect(parameter.localIdentifier, equals('propertiesToSavePtr'));
     });
 
+    test('projects IMapView', () {
+      final methodProjection = MethodProjection.fromTypeAndMethodName(
+          'Windows.ApplicationModel.DataTransfer.DataPackagePropertySetView',
+          'Split');
+      final parameter = methodProjection.parameters.first;
+      expect(parameter, isA<ObjectParameterProjection>());
+      expect(parameter.type, equals('IMapView<String, Object?>'));
+      expect(parameter.preamble, isEmpty);
+      expect(parameter.postamble, isEmpty);
+      expect(parameter.localIdentifier, equals('first.ptr'));
+    });
+
     test('projects IReference (1)', () {
       final methodProjection = MethodProjection.fromTypeAndMethodName(
           'Windows.Devices.Bluetooth.Advertisement.IBluetoothLEAdvertisement',


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

> (I did try it with Windows.ApplicationModel.DataTransfer.Clipboard, and that was less successful, because missing support for map projections.)

_Originally posted by @timsneath in https://github.com/dart-windows/dartwinrt/issues/189#issuecomment-1546173726_

@timsneath This PR should fix the issue.

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
