### PR TITLE
ci: ensure PR titles follow the Conventional Commits spec

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,41 @@
+name: 'PR Title is Conventional'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            windows_ai
+            windows_applicationmodel
+            windows_data
+            windows_devices
+            windows_foundation
+            windows_gaming
+            windows_globalization
+            windows_graphics
+            windows_management
+            windows_media
+            windows_networking
+            windows_perception
+            windows_security
+            windows_services
+            windows_storage
+            windows_system
+            windows_ui
+            windows_web
+            winrtgen


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

I intend to utilize [melos](https://github.com/invertase/melos) for automated versioning and publishing of packages moving forward. To achieve this, we must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification in our PR titles. This PR introduces a workflow to enforce that requirement.

Additionally, I have disabled _merge commits_ in this repository and will adopt _squash merging_ as our preferred method going forward to maintain a clean commit history (_yay!_).

@timsneath what do you think about these changes, are you happy with them?

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
