### PR TITLE
feat: support `double` types in collections

### DIFF
--- a/packages/windows_foundation/lib/src/collections/iiterable.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterable.dart
@@ -17,12 +17,19 @@ interface class IIterable<T> extends IInspectable {
   // vtable begins at 6, is 1 entries long.
   final T Function(Pointer<COMObject>)? _creator;
   final T Function(int)? _enumCreator;
+  final DoubleType? _doubleType;
   final IntType? _intType;
 
   /// Creates an instance of [IIterable] from the given [ptr].
   ///
-  /// [T] must be of type `bool`, `Guid`, `int`, `String`, `Uri`,
+  /// [T] must be of type `bool`, `double`, `Guid`, `int`, `String`, `Uri`,
   /// `IInspectable` (e.g.`StorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  ///
+  /// [doubleType] must be specified if [T] is `double`.
+  /// ```dart
+  /// final iterable =
+  ///     IIterable<double>.fromPtr(ptr, doubleType: DoubleType.float);
+  /// ```
   ///
   /// [intType] must be specified if [T] is `int`.
   /// ```dart
@@ -44,10 +51,16 @@ interface class IIterable<T> extends IInspectable {
     super.ptr, {
     T Function(Pointer<COMObject>)? creator,
     T Function(int)? enumCreator,
+    DoubleType? doubleType,
     IntType? intType,
   })  : _creator = creator,
         _enumCreator = enumCreator,
+        _doubleType = doubleType,
         _intType = intType {
+    if (doubleType == null && this is IIterable<double>) {
+      throw ArgumentError.notNull('doubleType');
+    }
+
     if (intType == null && this is IIterable<int>) {
       throw ArgumentError.notNull('intType');
     }
@@ -83,6 +96,9 @@ interface class IIterable<T> extends IInspectable {
     }
 
     return IIterator.fromPtr(retValuePtr,
-        creator: _creator, enumCreator: _enumCreator, intType: _intType);
+        creator: _creator,
+        enumCreator: _enumCreator,
+        doubleType: _doubleType,
+        intType: _intType);
   }
 }

--- a/packages/windows_foundation/lib/src/collections/iiterator.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterator.dart
@@ -19,8 +19,14 @@ abstract interface class IIterator<T> extends IInspectable {
 
   /// Creates an instance of [IIterator] from the given [ptr].
   ///
-  /// [T] must be of type `bool`, `Guid`, `int`, `String`, `Uri`,
+  /// [T] must be of type `bool`, `double` `Guid`, `int`, `String`, `Uri`,
   /// `IInspectable` (e.g.`StorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  ///
+  /// [doubleType] must be specified if [T] is `double`.
+  /// ```dart
+  /// final iterator =
+  ///     IIterator<double>.fromPtr(ptr, doubleType: DoubleType.float);
+  /// ```
   ///
   /// [intType] must be specified if [T] is `int`.
   /// ```dart
@@ -42,10 +48,20 @@ abstract interface class IIterator<T> extends IInspectable {
     Pointer<COMObject> ptr, {
     T Function(Pointer<COMObject>)? creator,
     T Function(int)? enumCreator,
+    DoubleType? doubleType,
     IntType? intType,
   }) {
     if (T == bool) return _IIteratorBool.fromPtr(ptr) as IIterator<T>;
     if (T == Guid) return _IIteratorGuid.fromPtr(ptr) as IIterator<T>;
+
+    if (T == double) {
+      if (doubleType == null) throw ArgumentError.notNull('doubleType');
+      final iterator = switch (doubleType) {
+        DoubleType.double => _IIteratorDouble.fromPtr(ptr),
+        DoubleType.float => _IIteratorFloat.fromPtr(ptr),
+      };
+      return iterator as IIterator<T>;
+    }
 
     if (T == int) {
       if (intType == null) throw ArgumentError.notNull('intType');

--- a/packages/windows_foundation/lib/src/collections/iiterator_part.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterator_part.dart
@@ -75,6 +75,136 @@ final class _IIteratorBool extends IIterator<bool> {
   }
 }
 
+final class _IIteratorDouble extends IIterator<double> {
+  _IIteratorDouble.fromPtr(super.ptr);
+
+  @override
+  double get current {
+    final retValuePtr = calloc<Double>();
+
+    try {
+      final hr = ptr.ref.vtable
+          .elementAt(6)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      HRESULT Function(VTablePointer lpVtbl,
+                          Pointer<Double> retValuePtr)>>>()
+          .value
+          .asFunction<
+              int Function(VTablePointer lpVtbl,
+                  Pointer<Double> retValuePtr)>()(ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  int getMany(int itemsSize, List<double> items) {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final pItemsArray = calloc<Double>(itemsSize);
+
+      final hr = ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              VTablePointer lpVtbl,
+                              Uint32 itemsSize,
+                              Pointer<Double> items,
+                              Pointer<Uint32> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(VTablePointer lpVtbl, int itemsSize,
+                      Pointer<Double> items, Pointer<Uint32> retValuePtr)>()(
+          ptr.ref.lpVtbl, itemsSize, pItemsArray, retValuePtr);
+
+      if (retValuePtr.value > 0) {
+        items.addAll(pItemsArray.toList(length: retValuePtr.value));
+      }
+      free(pItemsArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+}
+
+final class _IIteratorFloat extends IIterator<double> {
+  _IIteratorFloat.fromPtr(super.ptr);
+
+  @override
+  double get current {
+    final retValuePtr = calloc<Float>();
+
+    try {
+      final hr = ptr.ref.vtable
+          .elementAt(6)
+          .cast<
+              Pointer<
+                  NativeFunction<
+                      HRESULT Function(
+                          VTablePointer lpVtbl, Pointer<Float> retValuePtr)>>>()
+          .value
+          .asFunction<
+              int Function(VTablePointer lpVtbl,
+                  Pointer<Float> retValuePtr)>()(ptr.ref.lpVtbl, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  int getMany(int itemsSize, List<double> items) {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final pItemsArray = calloc<Float>(itemsSize);
+
+      final hr = ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              VTablePointer lpVtbl,
+                              Uint32 itemsSize,
+                              Pointer<Float> items,
+                              Pointer<Uint32> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(VTablePointer lpVtbl, int itemsSize,
+                      Pointer<Float> items, Pointer<Uint32> retValuePtr)>()(
+          ptr.ref.lpVtbl, itemsSize, pItemsArray, retValuePtr);
+
+      if (retValuePtr.value > 0) {
+        items.addAll(pItemsArray.toList(length: retValuePtr.value));
+      }
+      free(pItemsArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+}
+
 final class _IIteratorGuid extends IIterator<Guid> {
   _IIteratorGuid.fromPtr(super.ptr);
 

--- a/packages/windows_foundation/lib/src/collections/ivector_part.dart
+++ b/packages/windows_foundation/lib/src/collections/ivector_part.dart
@@ -184,6 +184,360 @@ final class _IVectorBool extends IVector<bool> {
   }
 }
 
+final class _IVectorDouble extends IVector<double> {
+  _IVectorDouble.fromPtr(super.ptr,
+      {required super.iterableIid, super.doubleType});
+
+  @override
+  double getAt(int index) {
+    final retValuePtr = calloc<Double>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(6)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(VTablePointer lpVtbl, Uint32 index,
+                              Pointer<Double> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(VTablePointer lpVtbl, int index,
+                      Pointer<Double> retValuePtr)>()(
+          ptr.ref.lpVtbl, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  bool indexOf(double value, Pointer<Uint32> index) {
+    final retValuePtr = calloc<Bool>();
+
+    try {
+      final hr =
+          ptr.ref.vtable
+                  .elementAt(9)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              HRESULT Function(
+                                  VTablePointer lpVtbl,
+                                  Double value,
+                                  Pointer<Uint32> index,
+                                  Pointer<Bool> retValuePtr)>>>()
+                  .value
+                  .asFunction<
+                      int Function(VTablePointer lpVtbl, double value,
+                          Pointer<Uint32> index, Pointer<Bool> retValuePtr)>()(
+              ptr.ref.lpVtbl, value, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  void setAt(int index, double value) {
+    final hr = ptr.ref.vtable
+        .elementAt(10)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+                        VTablePointer lpVtbl, Uint32 index, Double value)>>>()
+        .value
+        .asFunction<
+            int Function(VTablePointer lpVtbl, int index,
+                double value)>()(ptr.ref.lpVtbl, index, value);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+
+  @override
+  void insertAt(int index, double value) {
+    final hr = ptr.ref.vtable
+        .elementAt(11)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+                        VTablePointer lpVtbl, Uint32 index, Double value)>>>()
+        .value
+        .asFunction<
+            int Function(VTablePointer lpVtbl, int index,
+                double value)>()(ptr.ref.lpVtbl, index, value);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+
+  @override
+  void append(double value) {
+    final hr =
+        ptr.ref.vtable
+                .elementAt(13)
+                .cast<
+                    Pointer<
+                        NativeFunction<
+                            HRESULT Function(
+                                VTablePointer lpVtbl, Double value)>>>()
+                .value
+                .asFunction<int Function(VTablePointer lpVtbl, double value)>()(
+            ptr.ref.lpVtbl, value);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+
+  @override
+  int getMany(int startIndex, int itemsSize, List<double> items) {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final pItemsArray = calloc<Double>(itemsSize);
+
+      final hr = ptr.ref.vtable
+              .elementAt(16)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              VTablePointer lpVtbl,
+                              Uint32 startIndex,
+                              Uint32 itemsSize,
+                              Pointer<Double> items,
+                              Pointer<Uint32> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      VTablePointer lpVtbl,
+                      int startIndex,
+                      int itemsSize,
+                      Pointer<Double> items,
+                      Pointer<Uint32> retValuePtr)>()(
+          ptr.ref.lpVtbl, startIndex, itemsSize, pItemsArray, retValuePtr);
+
+      if (retValuePtr.value > 0) {
+        items.addAll(pItemsArray.toList(length: retValuePtr.value));
+      }
+      free(pItemsArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  void replaceAll(List<double> items) {
+    final pItemsArray = calloc<Double>(items.length);
+    for (var i = 0; i < items.length; i++) {
+      pItemsArray[i] = items.elementAt(i);
+    }
+
+    final hr = ptr.ref.vtable
+            .elementAt(17)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(VTablePointer lpVtbl, Uint32 itemsSize,
+                            Pointer<Double> items)>>>()
+            .value
+            .asFunction<
+                int Function(VTablePointer lpVtbl, int itemsSize,
+                    Pointer<Double> items)>()(
+        ptr.ref.lpVtbl, items.length, pItemsArray);
+
+    free(pItemsArray);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+}
+
+final class _IVectorFloat extends IVector<double> {
+  _IVectorFloat.fromPtr(super.ptr,
+      {required super.iterableIid, super.doubleType});
+
+  @override
+  double getAt(int index) {
+    final retValuePtr = calloc<Float>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(6)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(VTablePointer lpVtbl, Uint32 index,
+                              Pointer<Float> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(VTablePointer lpVtbl, int index,
+                      Pointer<Float> retValuePtr)>()(
+          ptr.ref.lpVtbl, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  bool indexOf(double value, Pointer<Uint32> index) {
+    final retValuePtr = calloc<Bool>();
+
+    try {
+      final hr =
+          ptr.ref.vtable
+                  .elementAt(9)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              HRESULT Function(
+                                  VTablePointer lpVtbl,
+                                  Float value,
+                                  Pointer<Uint32> index,
+                                  Pointer<Bool> retValuePtr)>>>()
+                  .value
+                  .asFunction<
+                      int Function(VTablePointer lpVtbl, double value,
+                          Pointer<Uint32> index, Pointer<Bool> retValuePtr)>()(
+              ptr.ref.lpVtbl, value, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  void setAt(int index, double value) {
+    final hr = ptr.ref.vtable
+        .elementAt(10)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+                        VTablePointer lpVtbl, Uint32 index, Float value)>>>()
+        .value
+        .asFunction<
+            int Function(VTablePointer lpVtbl, int index,
+                double value)>()(ptr.ref.lpVtbl, index, value);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+
+  @override
+  void insertAt(int index, double value) {
+    final hr = ptr.ref.vtable
+        .elementAt(11)
+        .cast<
+            Pointer<
+                NativeFunction<
+                    HRESULT Function(
+                        VTablePointer lpVtbl, Uint32 index, Float value)>>>()
+        .value
+        .asFunction<
+            int Function(VTablePointer lpVtbl, int index,
+                double value)>()(ptr.ref.lpVtbl, index, value);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+
+  @override
+  void append(double value) {
+    final hr = ptr.ref.vtable
+            .elementAt(13)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(VTablePointer lpVtbl, Float value)>>>()
+            .value
+            .asFunction<int Function(VTablePointer lpVtbl, double value)>()(
+        ptr.ref.lpVtbl, value);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+
+  @override
+  int getMany(int startIndex, int itemsSize, List<double> items) {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final pItemsArray = calloc<Float>(itemsSize);
+
+      final hr = ptr.ref.vtable
+              .elementAt(16)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              VTablePointer lpVtbl,
+                              Uint32 startIndex,
+                              Uint32 itemsSize,
+                              Pointer<Float> items,
+                              Pointer<Uint32> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      VTablePointer lpVtbl,
+                      int startIndex,
+                      int itemsSize,
+                      Pointer<Float> items,
+                      Pointer<Uint32> retValuePtr)>()(
+          ptr.ref.lpVtbl, startIndex, itemsSize, pItemsArray, retValuePtr);
+
+      if (retValuePtr.value > 0) {
+        items.addAll(pItemsArray.toList(length: retValuePtr.value));
+      }
+      free(pItemsArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  void replaceAll(List<double> items) {
+    final pItemsArray = calloc<Float>(items.length);
+    for (var i = 0; i < items.length; i++) {
+      pItemsArray[i] = items.elementAt(i);
+    }
+
+    final hr = ptr.ref.vtable
+            .elementAt(17)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(VTablePointer lpVtbl, Uint32 itemsSize,
+                            Pointer<Float> items)>>>()
+            .value
+            .asFunction<
+                int Function(VTablePointer lpVtbl, int itemsSize,
+                    Pointer<Float> items)>()(
+        ptr.ref.lpVtbl, items.length, pItemsArray);
+
+    free(pItemsArray);
+
+    if (FAILED(hr)) throw WindowsException(hr);
+  }
+}
+
 final class _IVectorGuid extends IVector<Guid> {
   _IVectorGuid.fromPtr(super.ptr, {required super.iterableIid});
 

--- a/packages/windows_foundation/lib/src/collections/ivectorview_part.dart
+++ b/packages/windows_foundation/lib/src/collections/ivectorview_part.dart
@@ -110,6 +110,210 @@ final class _IVectorViewBool extends IVectorView<bool> {
   }
 }
 
+final class _IVectorViewDouble extends IVectorView<double> {
+  _IVectorViewDouble.fromPtr(super.ptr,
+      {required super.iterableIid, super.doubleType});
+
+  @override
+  double getAt(int index) {
+    final retValuePtr = calloc<Double>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(6)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(VTablePointer lpVtbl, Uint32 index,
+                              Pointer<Double> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(VTablePointer lpVtbl, int index,
+                      Pointer<Double> retValuePtr)>()(
+          ptr.ref.lpVtbl, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  bool indexOf(double value, Pointer<Uint32> index) {
+    final retValuePtr = calloc<Bool>();
+
+    try {
+      final hr =
+          ptr.ref.vtable
+                  .elementAt(8)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              HRESULT Function(
+                                  VTablePointer lpVtbl,
+                                  Double value,
+                                  Pointer<Uint32> index,
+                                  Pointer<Bool> retValuePtr)>>>()
+                  .value
+                  .asFunction<
+                      int Function(VTablePointer lpVtbl, double value,
+                          Pointer<Uint32> index, Pointer<Bool> retValuePtr)>()(
+              ptr.ref.lpVtbl, value, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  int getMany(int startIndex, int itemsSize, List<double> items) {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final pItemsArray = calloc<Double>(itemsSize);
+
+      final hr = ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              VTablePointer lpVtbl,
+                              Uint32 startIndex,
+                              Uint32 itemsSize,
+                              Pointer<Double> items,
+                              Pointer<Uint32> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      VTablePointer lpVtbl,
+                      int startIndex,
+                      int itemsSize,
+                      Pointer<Double> items,
+                      Pointer<Uint32> retValuePtr)>()(
+          ptr.ref.lpVtbl, startIndex, itemsSize, pItemsArray, retValuePtr);
+
+      if (retValuePtr.value > 0) {
+        items.addAll(pItemsArray.toList(length: retValuePtr.value));
+      }
+      free(pItemsArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+}
+
+final class _IVectorViewFloat extends IVectorView<double> {
+  _IVectorViewFloat.fromPtr(super.ptr,
+      {required super.iterableIid, super.doubleType});
+
+  @override
+  double getAt(int index) {
+    final retValuePtr = calloc<Float>();
+
+    try {
+      final hr = ptr.ref.vtable
+              .elementAt(6)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(VTablePointer lpVtbl, Uint32 index,
+                              Pointer<Float> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(VTablePointer lpVtbl, int index,
+                      Pointer<Float> retValuePtr)>()(
+          ptr.ref.lpVtbl, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  bool indexOf(double value, Pointer<Uint32> index) {
+    final retValuePtr = calloc<Bool>();
+
+    try {
+      final hr =
+          ptr.ref.vtable
+                  .elementAt(8)
+                  .cast<
+                      Pointer<
+                          NativeFunction<
+                              HRESULT Function(
+                                  VTablePointer lpVtbl,
+                                  Float value,
+                                  Pointer<Uint32> index,
+                                  Pointer<Bool> retValuePtr)>>>()
+                  .value
+                  .asFunction<
+                      int Function(VTablePointer lpVtbl, double value,
+                          Pointer<Uint32> index, Pointer<Bool> retValuePtr)>()(
+              ptr.ref.lpVtbl, value, index, retValuePtr);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+
+  @override
+  int getMany(int startIndex, int itemsSize, List<double> items) {
+    final retValuePtr = calloc<Uint32>();
+
+    try {
+      final pItemsArray = calloc<Float>(itemsSize);
+
+      final hr = ptr.ref.vtable
+              .elementAt(9)
+              .cast<
+                  Pointer<
+                      NativeFunction<
+                          HRESULT Function(
+                              VTablePointer lpVtbl,
+                              Uint32 startIndex,
+                              Uint32 itemsSize,
+                              Pointer<Float> items,
+                              Pointer<Uint32> retValuePtr)>>>()
+              .value
+              .asFunction<
+                  int Function(
+                      VTablePointer lpVtbl,
+                      int startIndex,
+                      int itemsSize,
+                      Pointer<Float> items,
+                      Pointer<Uint32> retValuePtr)>()(
+          ptr.ref.lpVtbl, startIndex, itemsSize, pItemsArray, retValuePtr);
+
+      if (retValuePtr.value > 0) {
+        items.addAll(pItemsArray.toList(length: retValuePtr.value));
+      }
+      free(pItemsArray);
+
+      if (FAILED(hr)) throw WindowsException(hr);
+
+      return retValuePtr.value;
+    } finally {
+      free(retValuePtr);
+    }
+  }
+}
+
 final class _IVectorViewGuid extends IVectorView<Guid> {
   _IVectorViewGuid.fromPtr(super.ptr, {required super.iterableIid});
 

--- a/packages/winrtgen/lib/src/constants/generic_types.dart
+++ b/packages/winrtgen/lib/src/constants/generic_types.dart
@@ -60,8 +60,8 @@ const _mapTypeArgPairs = <(TypeArg, TypeArg)>[
 
 /// The common type arguments for `IIterator`, `IVector`, and `IVectorView`.
 const _vectorTypeArgs = <TypeArg>[
-  TypeArg.bool_, TypeArg.guid, TypeArg.inspectable, TypeArg.int16, //
-  TypeArg.int32, TypeArg.int64, TypeArg.string, TypeArg.uint8, //
-  TypeArg.uint16, TypeArg.uint32, TypeArg.uint64, TypeArg.uri, //
-  TypeArg.winrtEnum, TypeArg.winrtFlagsEnum
+  TypeArg.bool_, TypeArg.double, TypeArg.float, TypeArg.guid, //
+  TypeArg.inspectable, TypeArg.int16, TypeArg.int32, TypeArg.int64, //
+  TypeArg.string, TypeArg.uint8, TypeArg.uint16, TypeArg.uint32, //
+  TypeArg.uint64, TypeArg.uri, TypeArg.winrtEnum, TypeArg.winrtFlagsEnum //
 ];

--- a/packages/winrtgen/lib/src/models/type_arg.dart
+++ b/packages/winrtgen/lib/src/models/type_arg.dart
@@ -64,6 +64,10 @@ enum TypeArg {
           orElse: () => throw ArgumentError.value(
               name, 'name', 'No enum value with that name'));
 
+  /// Whether this is [TypeArg.double] or [TypeArg.float].
+  bool get isDouble =>
+      switch (this) { TypeArg.double || TypeArg.float => true, _ => false };
+
   /// Whether this is [TypeArg.winrtEnum] or [TypeArg.winrtFlagsEnum].
   bool get isEnum => switch (this) {
         TypeArg.winrtEnum || TypeArg.winrtFlagsEnum => true,

--- a/packages/winrtgen/lib/src/projections/generic_interface.dart
+++ b/packages/winrtgen/lib/src/projections/generic_interface.dart
@@ -125,11 +125,17 @@ final class GenericInterfaceProjection extends InterfaceProjection {
         if (typeArgs case [final typeArg1, final typeArg2]) ...{
           if (typeArg1.isEnum) 'required this.enumKeyCreator',
           if (shortName case 'IMap' || 'IMapView' || 'IVector' || 'IVectorView'
+              when typeArg1.isDouble)
+            'super.doubleType',
+          if (shortName case 'IMap' || 'IMapView' || 'IVector' || 'IVectorView'
               when typeArg1.isInt)
             'super.intType',
           if (typeArg2.isInspectable) 'required this.creator',
           if (typeArg2.isEnum) 'required this.enumCreator'
         } else if (typeArgs case [final typeArg]) ...{
+          if (shortName case 'IMap' || 'IMapView' || 'IVector' || 'IVectorView'
+              when typeArg.isDouble)
+            'super.doubleType',
           if (shortName case 'IMap' || 'IMapView' || 'IVector' || 'IVectorView'
               when typeArg.isInt)
             'super.intType',

--- a/packages/winrtgen/lib/src/projections/types/vector.dart
+++ b/packages/winrtgen/lib/src/projections/types/vector.dart
@@ -34,6 +34,13 @@ mixin _VectorMixin on MethodProjection {
     final iterableIid =
         iterableIidFromVectorType(returnTypeProjection.typeIdentifier);
 
+    // If the type argument is a double, 'doubleType' parameter must be
+    // specified so that the IVector and IVectorView implementations can use
+    // the appropriate native double type
+    final doubleType = vectorTypeArg == 'double'
+        ? 'DoubleType.${typeProjection.nativeType.toLowerCase()}'
+        : null;
+
     // If the type argument is an int, 'intType' parameter must be specified so
     // that the IVector and IVectorView implementations can use the appropriate
     // native integer type
@@ -46,6 +53,9 @@ mixin _VectorMixin on MethodProjection {
       args.add('enumCreator: $creator');
     } else if (creator != null) {
       args.add('creator: $creator');
+    }
+    if (doubleType != null) {
+      args.add('doubleType: $doubleType');
     }
     if (intType != null) {
       args.add('intType: $intType');

--- a/packages/winrtgen/test/projections/generic_interface_test.dart
+++ b/packages/winrtgen/test/projections/generic_interface_test.dart
@@ -263,6 +263,24 @@ void main() {
 
       test('(4)', () {
         final projection = GenericInterfaceProjection.from(
+            'Windows.Foundation.Collections.IVector`1', TypeArg.int32);
+        expect(
+            projection.namedConstructor,
+            equals(
+                '_IVectorInt32.fromPtr(super.ptr, {required super.iterableIid, super.intType});'));
+      });
+
+      test('(5)', () {
+        final projection = GenericInterfaceProjection.from(
+            'Windows.Foundation.Collections.IVectorView`1', TypeArg.float);
+        expect(
+            projection.namedConstructor,
+            equals(
+                '_IVectorViewFloat.fromPtr(super.ptr, {required super.iterableIid, super.doubleType});'));
+      });
+
+      test('(6)', () {
+        final projection = GenericInterfaceProjection.from(
             'Windows.Foundation.Collections.IMap`2',
             TypeArg.string,
             TypeArg.object);
@@ -272,7 +290,7 @@ void main() {
                 '_IMapStringObject.fromPtr(super.ptr, {required super.iterableIid});'));
       });
 
-      test('(5)', () {
+      test('(7)', () {
         final projection = GenericInterfaceProjection.from(
             'Windows.Foundation.Collections.IMap`2',
             TypeArg.string,
@@ -283,7 +301,7 @@ void main() {
                 '_IMapStringInspectable.fromPtr(super.ptr, {required super.iterableIid, required this.creator}) : super(creator: creator);'));
       });
 
-      test('(6)', () {
+      test('(8)', () {
         final projection = GenericInterfaceProjection.from(
             'Windows.Foundation.Collections.IMap`2',
             TypeArg.winrtEnum,

--- a/packages/winrtgen/test/projections/method_test.dart
+++ b/packages/winrtgen/test/projections/method_test.dart
@@ -338,7 +338,7 @@ void main() {
           equals('IVector<BackgroundTransferFileRange> getDownloadedRanges()'));
     });
 
-    test('projects IVectorView', () {
+    test('projects IVectorView 1', () {
       final projection = MethodProjection.fromTypeAndMethodName(
           'Windows.Globalization.ApplicationLanguages', 'GetLanguagesForUser');
       expect(projection, isA<VectorViewMethodProjection>());
@@ -353,6 +353,23 @@ void main() {
               'int Function(VTablePointer lpVtbl, VTablePointer user, Pointer<COMObject> retValuePtr)'));
       expect(projection.methodHeader,
           equals('List<String> getLanguagesForUser(User? user)'));
+    });
+
+    test('projects IVectorView 2', () {
+      final projection = MethodProjection.fromTypeAndMethodName(
+          'Windows.AI.MachineLearning.TensorFloat', 'GetAsVectorView');
+      expect(projection, isA<VectorViewMethodProjection>());
+      expect(projection.returnType, equals('List<double>'));
+      expect(
+          projection.nativePrototype,
+          equals(
+              'HRESULT Function(VTablePointer lpVtbl, Pointer<COMObject> retValuePtr)'));
+      expect(
+          projection.dartPrototype,
+          equals(
+              'int Function(VTablePointer lpVtbl, Pointer<COMObject> retValuePtr)'));
+      expect(projection.methodHeader, equals('List<double> getAsVectorView()'));
+      expect(projection.toString(), contains('doubleType: DoubleType.float'));
     });
 
     test('projects List<int>', () {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Adds support for `double` types in collection interfaces (`IIterator`, `IIterable`, `IVector`, and `IVectorView`).

## Related Issue

Part of #261 

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🧪 `test` -- Test
- [ ] 🗑️ `chore` -- Chore
