### PR TITLE
fix!: some Vector type arguments are now nullable

### DIFF
--- a/packages/windows_ai/lib/src/machinelearning/iimagefeaturevalue.dart
+++ b/packages/windows_ai/lib/src/machinelearning/iimagefeaturevalue.dart
@@ -46,7 +46,7 @@ class IImageFeatureValue extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/iimagefeaturevaluestatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/iimagefeaturevaluestatics.dart
@@ -54,7 +54,7 @@ class IImageFeatureValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodel.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodel.dart
@@ -176,7 +176,7 @@ class ILearningModel extends IInspectable {
     return mapView.toMap();
   }
 
-  List<ILearningModelFeatureDescriptor> get inputFeatures {
+  List<ILearningModelFeatureDescriptor?> get inputFeatures {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -196,14 +196,14 @@ class ILearningModel extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<ILearningModelFeatureDescriptor>.fromPtr(
+    final vectorView = IVectorView<ILearningModelFeatureDescriptor?>.fromPtr(
         retValuePtr,
         iterableIid: '{0fa50877-6792-56b7-af46-430a8901894a}',
         creator: ILearningModelFeatureDescriptor.fromPtr);
     return vectorView.toList();
   }
 
-  List<ILearningModelFeatureDescriptor> get outputFeatures {
+  List<ILearningModelFeatureDescriptor?> get outputFeatures {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -223,7 +223,7 @@ class ILearningModel extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<ILearningModelFeatureDescriptor>.fromPtr(
+    final vectorView = IVectorView<ILearningModelFeatureDescriptor?>.fromPtr(
         retValuePtr,
         iterableIid: '{0fa50877-6792-56b7-af46-430a8901894a}',
         creator: ILearningModelFeatureDescriptor.fromPtr);

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodeldevice.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodeldevice.dart
@@ -72,7 +72,7 @@ class ILearningModelDevice extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodeldevicestatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodeldevicestatics.dart
@@ -55,7 +55,7 @@ class ILearningModelDeviceStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelsession.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelsession.dart
@@ -51,7 +51,7 @@ class ILearningModelSession extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -79,7 +79,7 @@ class ILearningModelSession extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -209,7 +209,7 @@ class ILearningModelSession extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -246,7 +246,7 @@ class ILearningModelSession extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelstatics.dart
@@ -114,7 +114,7 @@ class ILearningModelStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -147,7 +147,7 @@ class ILearningModelStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -263,7 +263,7 @@ class ILearningModelStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -304,7 +304,7 @@ class ILearningModelStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/imapfeaturedescriptor.dart
+++ b/packages/windows_ai/lib/src/machinelearning/imapfeaturedescriptor.dart
@@ -73,7 +73,7 @@ class IMapFeatureDescriptor extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/isequencefeaturedescriptor.dart
+++ b/packages/windows_ai/lib/src/machinelearning/isequencefeaturedescriptor.dart
@@ -48,7 +48,7 @@ class ISequenceFeatureDescriptor extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorbooleanstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorbooleanstatics.dart
@@ -48,7 +48,7 @@ class ITensorBooleanStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorBooleanStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorBooleanStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorBooleanStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorbooleanstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorbooleanstatics2.dart
@@ -72,7 +72,7 @@ class ITensorBooleanStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorBooleanStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensordoublestatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensordoublestatics.dart
@@ -48,7 +48,7 @@ class ITensorDoubleStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorDoubleStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorDoubleStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorDoubleStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensordoublestatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensordoublestatics2.dart
@@ -72,7 +72,7 @@ class ITensorDoubleStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorDoubleStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorfloat16bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorfloat16bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorFloat16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorFloat16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorFloat16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorFloat16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorfloat16bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorfloat16bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorFloat16BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorFloat16BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorfloatstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorfloatstatics.dart
@@ -48,7 +48,7 @@ class ITensorFloatStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorFloatStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorFloatStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorFloatStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorfloatstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorfloatstatics2.dart
@@ -72,7 +72,7 @@ class ITensorFloatStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorFloatStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint16bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint16bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint16bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint16bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorInt16BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorInt16BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint32bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint32bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint32bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint32bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorInt32BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorInt32BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint64bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint64bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint64bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint64bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorInt64BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorInt64BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint8bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint8bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorint8bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorint8bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorInt8BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorInt8BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorstringstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorstringstatics.dart
@@ -48,7 +48,7 @@ class ITensorStringStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorStringStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -140,7 +140,7 @@ class ITensorStringStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -188,7 +188,7 @@ class ITensorStringStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensorstringstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorstringstatics2.dart
@@ -74,7 +74,7 @@ class ITensorStringStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint16bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint16bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorUInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorUInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorUInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorUInt16BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint16bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint16bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorUInt16BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorUInt16BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint32bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint32bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorUInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorUInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorUInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorUInt32BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint32bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint32bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorUInt32BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorUInt32BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint64bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint64bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorUInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorUInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorUInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorUInt64BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint64bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint64bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorUInt64BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorUInt64BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint8bitstatics.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint8bitstatics.dart
@@ -48,7 +48,7 @@ class ITensorUInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class ITensorUInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -137,7 +137,7 @@ class ITensorUInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class ITensorUInt8BitStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/itensoruint8bitstatics2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensoruint8bitstatics2.dart
@@ -72,7 +72,7 @@ class ITensorUInt8BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -116,7 +116,7 @@ class ITensorUInt8BitStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ai/lib/src/machinelearning/learningmodel.dart
+++ b/packages/windows_ai/lib/src/machinelearning/learningmodel.dart
@@ -100,11 +100,11 @@ class LearningModel extends IInspectable implements ILearningModel, IClosable {
   Map<String, String> get metadata => _iLearningModel.metadata;
 
   @override
-  List<ILearningModelFeatureDescriptor> get inputFeatures =>
+  List<ILearningModelFeatureDescriptor?> get inputFeatures =>
       _iLearningModel.inputFeatures;
 
   @override
-  List<ILearningModelFeatureDescriptor> get outputFeatures =>
+  List<ILearningModelFeatureDescriptor?> get outputFeatures =>
       _iLearningModel.outputFeatures;
 
   late final _iClosable = IClosable.from(this);

--- a/packages/windows_ai/test/collections_test.dart
+++ b/packages/windows_ai/test/collections_test.dart
@@ -60,8 +60,11 @@ void main() {
 
       test('getAt returns elements', () {
         final vectorView = getVectorView();
-        final element = vectorView.getAt(0);
-        expect(element, equals(1));
+        expect(vectorView.size, equals(4));
+        expect(vectorView.getAt(0), equals(1));
+        expect(vectorView.getAt(1), equals(2));
+        expect(vectorView.getAt(2), equals(3));
+        expect(vectorView.getAt(3), equals(4));
       });
 
       test('indexOf finds element', () {

--- a/packages/windows_applicationmodel/lib/src/appinstallerinfo.dart
+++ b/packages/windows_applicationmodel/lib/src/appinstallerinfo.dart
@@ -68,17 +68,17 @@ class AppInstallerInfo extends IInspectable
   DateTime? get pausedUntil => _iAppInstallerInfo2.pausedUntil;
 
   @override
-  List<Uri> get updateUris => _iAppInstallerInfo2.updateUris;
+  List<Uri?> get updateUris => _iAppInstallerInfo2.updateUris;
 
   @override
-  List<Uri> get repairUris => _iAppInstallerInfo2.repairUris;
+  List<Uri?> get repairUris => _iAppInstallerInfo2.repairUris;
 
   @override
-  List<Uri> get dependencyPackageUris =>
+  List<Uri?> get dependencyPackageUris =>
       _iAppInstallerInfo2.dependencyPackageUris;
 
   @override
-  List<Uri> get optionalPackageUris => _iAppInstallerInfo2.optionalPackageUris;
+  List<Uri?> get optionalPackageUris => _iAppInstallerInfo2.optionalPackageUris;
 
   @override
   AppInstallerPolicySource get policySource => _iAppInstallerInfo2.policySource;

--- a/packages/windows_applicationmodel/lib/src/core/iapplistentry.dart
+++ b/packages/windows_applicationmodel/lib/src/core/iapplistentry.dart
@@ -47,7 +47,7 @@ class IAppListEntry extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/core/iapplistentry4.dart
+++ b/packages/windows_applicationmodel/lib/src/core/iapplistentry4.dart
@@ -47,7 +47,7 @@ class IAppListEntry4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/iappdisplayinfo.dart
+++ b/packages/windows_applicationmodel/lib/src/iappdisplayinfo.dart
@@ -100,7 +100,7 @@ class IAppDisplayInfo extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/iappinfo.dart
+++ b/packages/windows_applicationmodel/lib/src/iappinfo.dart
@@ -97,7 +97,7 @@ class IAppInfo extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/iappinfo2.dart
+++ b/packages/windows_applicationmodel/lib/src/iappinfo2.dart
@@ -47,7 +47,7 @@ class IAppInfo2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/iappinfostatics.dart
+++ b/packages/windows_applicationmodel/lib/src/iappinfostatics.dart
@@ -48,7 +48,7 @@ class IAppInfoStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -82,7 +82,7 @@ class IAppInfoStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -118,7 +118,7 @@ class IAppInfoStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/iappinstallerinfo.dart
+++ b/packages/windows_applicationmodel/lib/src/iappinstallerinfo.dart
@@ -45,7 +45,7 @@ class IAppInstallerInfo extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/iappinstallerinfo2.dart
+++ b/packages/windows_applicationmodel/lib/src/iappinstallerinfo2.dart
@@ -265,7 +265,7 @@ class IAppInstallerInfo2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -275,7 +275,7 @@ class IAppInstallerInfo2 extends IInspectable {
     return reference.value;
   }
 
-  List<Uri> get updateUris {
+  List<Uri?> get updateUris {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -295,12 +295,12 @@ class IAppInstallerInfo2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Uri>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Uri?>.fromPtr(retValuePtr,
         iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}');
     return vectorView.toList();
   }
 
-  List<Uri> get repairUris {
+  List<Uri?> get repairUris {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -320,12 +320,12 @@ class IAppInstallerInfo2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Uri>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Uri?>.fromPtr(retValuePtr,
         iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}');
     return vectorView.toList();
   }
 
-  List<Uri> get dependencyPackageUris {
+  List<Uri?> get dependencyPackageUris {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -345,12 +345,12 @@ class IAppInstallerInfo2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Uri>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Uri?>.fromPtr(retValuePtr,
         iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}');
     return vectorView.toList();
   }
 
-  List<Uri> get optionalPackageUris {
+  List<Uri?> get optionalPackageUris {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -370,7 +370,7 @@ class IAppInstallerInfo2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Uri>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Uri?>.fromPtr(retValuePtr,
         iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}');
     return vectorView.toList();
   }

--- a/packages/windows_applicationmodel/lib/src/ipackage.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage.dart
@@ -49,7 +49,7 @@ class IPackage extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -77,7 +77,7 @@ class IPackage extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -109,7 +109,7 @@ class IPackage extends IInspectable {
     }
   }
 
-  List<Package> get dependencies {
+  List<Package?> get dependencies {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -129,7 +129,7 @@ class IPackage extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Package>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Package?>.fromPtr(retValuePtr,
         iterableIid: '{69ad6aa7-0c49-5f27-a5eb-ef4d59467b6d}',
         creator: Package.fromPtr);
     return vectorView.toList();

--- a/packages/windows_applicationmodel/lib/src/ipackage2.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage2.dart
@@ -120,7 +120,7 @@ class IPackage2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/ipackage3.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage3.dart
@@ -48,7 +48,7 @@ class IPackage3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -80,7 +80,7 @@ class IPackage3 extends IInspectable {
     }
   }
 
-  Future<List<AppListEntry>> getAppListEntriesAsync() {
+  Future<List<AppListEntry?>> getAppListEntriesAsync() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -100,7 +100,7 @@ class IPackage3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<AppListEntry>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<AppListEntry?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: AppListEntry.fromPtr,

--- a/packages/windows_applicationmodel/lib/src/ipackage5.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage5.dart
@@ -27,7 +27,7 @@ class IPackage5 extends IInspectable {
   factory IPackage5.from(IInspectable interface) =>
       IPackage5.fromPtr(interface.toInterface(IID_IPackage5));
 
-  Future<IVector<PackageContentGroup>> getContentGroupsAsync() {
+  Future<IVector<PackageContentGroup?>> getContentGroupsAsync() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -48,7 +48,7 @@ class IPackage5 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVector<PackageContentGroup>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVector<PackageContentGroup?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVector.fromPtr(ptr,
                 creator: PackageContentGroup.fromPtr,
                 iterableIid: '{d7dd1456-4805-5768-a25d-99641b096491}'));
@@ -85,7 +85,7 @@ class IPackage5 extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<IVector<PackageContentGroup>> stageContentGroupsAsync(
+  Future<IVector<PackageContentGroup?>> stageContentGroupsAsync(
       IIterable<String>? names) {
     final retValuePtr = calloc<COMObject>();
     final namesPtr = names == null
@@ -118,14 +118,14 @@ class IPackage5 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVector<PackageContentGroup>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVector<PackageContentGroup?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVector.fromPtr(ptr,
                 creator: PackageContentGroup.fromPtr,
                 iterableIid: '{d7dd1456-4805-5768-a25d-99641b096491}'));
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<IVector<PackageContentGroup>> stageContentGroupsWithPriorityAsync(
+  Future<IVector<PackageContentGroup?>> stageContentGroupsWithPriorityAsync(
       IIterable<String>? names, bool moveToHeadOfQueue) {
     final retValuePtr = calloc<COMObject>();
     final namesPtr = names == null
@@ -158,7 +158,7 @@ class IPackage5 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVector<PackageContentGroup>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVector<PackageContentGroup?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVector.fromPtr(ptr,
                 creator: PackageContentGroup.fromPtr,
                 iterableIid: '{d7dd1456-4805-5768-a25d-99641b096491}'));

--- a/packages/windows_applicationmodel/lib/src/ipackage6.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage6.dart
@@ -48,7 +48,7 @@ class IPackage6 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/ipackage7.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage7.dart
@@ -46,7 +46,7 @@ class IPackage7 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -74,7 +74,7 @@ class IPackage7 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/ipackage8.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage8.dart
@@ -48,7 +48,7 @@ class IPackage8 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -76,7 +76,7 @@ class IPackage8 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -104,7 +104,7 @@ class IPackage8 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -286,7 +286,7 @@ class IPackage8 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -294,7 +294,7 @@ class IPackage8 extends IInspectable {
     return RandomAccessStreamReference.fromPtr(retValuePtr);
   }
 
-  List<AppListEntry> getAppListEntries() {
+  List<AppListEntry?> getAppListEntries() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -314,7 +314,7 @@ class IPackage8 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<AppListEntry>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<AppListEntry?>.fromPtr(retValuePtr,
         iterableIid: '{86f4d4ef-d8fd-5fb5-807c-72da8fc9e544}',
         creator: AppListEntry.fromPtr);
     return vectorView.toList();

--- a/packages/windows_applicationmodel/lib/src/ipackage9.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage9.dart
@@ -28,7 +28,7 @@ class IPackage9 extends IInspectable {
   factory IPackage9.from(IInspectable interface) =>
       IPackage9.fromPtr(interface.toInterface(IID_IPackage9));
 
-  IVector<Package> findRelatedPackages(FindRelatedPackagesOptions? options) {
+  IVector<Package?> findRelatedPackages(FindRelatedPackagesOptions? options) {
     final retValuePtr = calloc<COMObject>();
     final optionsPtr = options == null ? nullptr : options.ptr.ref.lpVtbl;
 

--- a/packages/windows_applicationmodel/lib/src/ipackagecontentgroup.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackagecontentgroup.dart
@@ -49,7 +49,7 @@ class IPackageContentGroup extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/ipackagestatics.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackagestatics.dart
@@ -47,7 +47,7 @@ class IPackageStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_applicationmodel/lib/src/package.dart
+++ b/packages/windows_applicationmodel/lib/src/package.dart
@@ -69,7 +69,7 @@ class Package extends IInspectable
   bool get isFramework => _iPackage.isFramework;
 
   @override
-  List<Package> get dependencies => _iPackage.dependencies;
+  List<Package?> get dependencies => _iPackage.dependencies;
 
   late final _iPackage2 = IPackage2.from(this);
 
@@ -103,7 +103,7 @@ class Package extends IInspectable
   DateTime get installedDate => _iPackage3.installedDate;
 
   @override
-  Future<List<AppListEntry>> getAppListEntriesAsync() =>
+  Future<List<AppListEntry?>> getAppListEntriesAsync() =>
       _iPackage3.getAppListEntriesAsync();
 
   late final _iPackageWithMetadata = IPackageWithMetadata.from(this);
@@ -134,7 +134,7 @@ class Package extends IInspectable
   late final _iPackage5 = IPackage5.from(this);
 
   @override
-  Future<IVector<PackageContentGroup>> getContentGroupsAsync() =>
+  Future<IVector<PackageContentGroup?>> getContentGroupsAsync() =>
       _iPackage5.getContentGroupsAsync();
 
   @override
@@ -142,12 +142,12 @@ class Package extends IInspectable
       _iPackage5.getContentGroupAsync(name);
 
   @override
-  Future<IVector<PackageContentGroup>> stageContentGroupsAsync(
+  Future<IVector<PackageContentGroup?>> stageContentGroupsAsync(
           IIterable<String>? names) =>
       _iPackage5.stageContentGroupsAsync(names);
 
   @override
-  Future<IVector<PackageContentGroup>> stageContentGroupsWithPriorityAsync(
+  Future<IVector<PackageContentGroup?>> stageContentGroupsWithPriorityAsync(
           IIterable<String>? names, bool moveToHeadOfQueue) =>
       _iPackage5.stageContentGroupsWithPriorityAsync(names, moveToHeadOfQueue);
 
@@ -208,7 +208,7 @@ class Package extends IInspectable
       _iPackage8.getLogoAsRandomAccessStreamReference(size);
 
   @override
-  List<AppListEntry> getAppListEntries() => _iPackage8.getAppListEntries();
+  List<AppListEntry?> getAppListEntries() => _iPackage8.getAppListEntries();
 
   @override
   bool get isStub => _iPackage8.isStub;
@@ -216,7 +216,7 @@ class Package extends IInspectable
   late final _iPackage9 = IPackage9.from(this);
 
   @override
-  IVector<Package> findRelatedPackages(FindRelatedPackagesOptions? options) =>
+  IVector<Package?> findRelatedPackages(FindRelatedPackagesOptions? options) =>
       _iPackage9.findRelatedPackages(options);
 
   @override

--- a/packages/windows_data/example/xmldom.dart
+++ b/packages/windows_data/example/xmldom.dart
@@ -7,6 +7,15 @@
 
 import 'package:windows_data/windows_data.dart';
 
+void printProduct(IXmlNode? product) {
+  if (product == null) return;
+  final id = product.attributes.getNamedItem('id')?.nodeValue;
+  final title = product.attributes.getNamedItem('title')?.nodeValue;
+  final hot = product.attributes.getNamedItem('hot')?.nodeValue;
+  final price = product.selectNodes('price').item(0)?.firstChild?.nodeValue;
+  print('Product id: $id, title: $title, hot: $hot, price: $price');
+}
+
 void main() {
   const xmlString = '''
 <?xml version="1.0" encoding="utf-8"?>
@@ -28,11 +37,7 @@ void main() {
   // Retrieve the attributes of the products
   final products = doc.getElementsByTagName('product');
   for (final product in products.toList()) {
-    final id = product.attributes.getNamedItem('id')?.nodeValue;
-    final title = product.attributes.getNamedItem('title')?.nodeValue;
-    final hot = product.attributes.getNamedItem('hot')?.nodeValue;
-    final price = product.selectNodes('price').item(0)?.firstChild?.nodeValue;
-    print('Product id: $id, title: $title, hot: $hot, price: $price');
+    printProduct(product);
   }
 
   // Mark 'hot' attribute to '1' if 'sell10days' is greater than 'InStore'

--- a/packages/windows_data/lib/src/json/ijsonobject.dart
+++ b/packages/windows_data/lib/src/json/ijsonobject.dart
@@ -55,7 +55,7 @@ class IJsonObject extends IInspectable implements IJsonValue {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
@@ -67,7 +67,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonvaluestatics.dart
+++ b/packages/windows_data/lib/src/json/ijsonvaluestatics.dart
@@ -51,7 +51,7 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -112,7 +112,7 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -141,7 +141,7 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -173,7 +173,7 @@ class IJsonValueStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/ijsonvaluestatics2.dart
+++ b/packages/windows_data/lib/src/json/ijsonvaluestatics2.dart
@@ -47,7 +47,7 @@ class IJsonValueStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/json/jsonarray.dart
+++ b/packages/windows_data/lib/src/json/jsonarray.dart
@@ -26,8 +26,8 @@ class JsonArray extends IInspectable
     implements
         IJsonArray,
         IJsonValue,
-        IVector<IJsonValue>,
-        IIterable<IJsonValue>,
+        IVector<IJsonValue?>,
+        IIterable<IJsonValue?>,
         IStringable {
   JsonArray() : super(activateClass(_className));
   JsonArray.fromPtr(super.ptr);
@@ -83,35 +83,36 @@ class JsonArray extends IInspectable
   @override
   JsonObject getObject() => _iJsonValue.getObject();
 
-  late final _iVector = IVector<IJsonValue>.fromPtr(
+  late final _iVector = IVector<IJsonValue?>.fromPtr(
       toInterface('{d44662bc-dce3-59a8-9272-4b210f33908b}'),
       creator: IJsonValue.fromPtr,
       iterableIid: '{cb0492b6-4113-55cf-b2c5-99eb428ba493}');
 
   @override
-  IJsonValue getAt(int index) => _iVector.getAt(index);
+  IJsonValue? getAt(int index) => _iVector.getAt(index);
 
   @override
   int get size => _iVector.size;
 
   @override
-  List<IJsonValue> getView() => _iVector.getView();
+  List<IJsonValue?> getView() => _iVector.getView();
 
   @override
-  bool indexOf(IJsonValue value, Pointer<Uint32> index) =>
+  bool indexOf(IJsonValue? value, Pointer<Uint32> index) =>
       _iVector.indexOf(value, index);
 
   @override
-  void setAt(int index, IJsonValue value) => _iVector.setAt(index, value);
+  void setAt(int index, IJsonValue? value) => _iVector.setAt(index, value);
 
   @override
-  void insertAt(int index, IJsonValue value) => _iVector.insertAt(index, value);
+  void insertAt(int index, IJsonValue? value) =>
+      _iVector.insertAt(index, value);
 
   @override
   void removeAt(int index) => _iVector.removeAt(index);
 
   @override
-  void append(IJsonValue value) => _iVector.append(value);
+  void append(IJsonValue? value) => _iVector.append(value);
 
   @override
   void removeAtEnd() => _iVector.removeAtEnd();
@@ -120,26 +121,26 @@ class JsonArray extends IInspectable
   void clear() => _iVector.clear();
 
   @override
-  int getMany(int startIndex, int itemsSize, List<IJsonValue> items) =>
+  int getMany(int startIndex, int itemsSize, List<IJsonValue?> items) =>
       _iVector.getMany(startIndex, itemsSize, items);
 
   @override
-  void replaceAll(List<IJsonValue> items) => _iVector.replaceAll(items);
+  void replaceAll(List<IJsonValue?> items) => _iVector.replaceAll(items);
 
   @override
-  IIterator<IJsonValue> first() => _iVector.first();
+  IIterator<IJsonValue?> first() => _iVector.first();
 
   @override
-  List<IJsonValue> toList() => _iVector.toList();
+  List<IJsonValue?> toList() => _iVector.toList();
 
   @override
-  IJsonValue operator [](int index) => _iVector[index];
+  IJsonValue? operator [](int index) => _iVector[index];
 
   @override
-  void operator []=(int index, IJsonValue value) => _iVector[index] = value;
+  void operator []=(int index, IJsonValue? value) => _iVector[index] = value;
 
   @override
-  List<IJsonValue> operator +(List<IJsonValue> other) => toList() + other;
+  List<IJsonValue?> operator +(List<IJsonValue?> other) => toList() + other;
 
   late final _iStringable = IStringable.from(this);
 

--- a/packages/windows_data/lib/src/xml/dom/ixmldocument.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocument.dart
@@ -64,7 +64,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -92,7 +92,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -120,7 +120,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -152,7 +152,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -180,7 +180,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -212,7 +212,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -244,7 +244,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -279,7 +279,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -311,7 +311,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -343,7 +343,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -402,7 +402,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -463,7 +463,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -499,7 +499,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -531,7 +531,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -565,7 +565,7 @@ class IXmlDocument extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/xml/dom/ixmlelement.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlelement.dart
@@ -163,7 +163,7 @@ class IXmlElement extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -196,7 +196,7 @@ class IXmlElement extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -229,7 +229,7 @@ class IXmlElement extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -373,7 +373,7 @@ class IXmlElement extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -409,7 +409,7 @@ class IXmlElement extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/xml/dom/ixmlnamednodemap.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnamednodemap.dart
@@ -21,7 +21,7 @@ import 'ixmlnode.dart';
 const IID_IXmlNamedNodeMap = '{b3a69eb0-aab0-4b82-a6fa-b1453f7c021b}';
 
 class IXmlNamedNodeMap extends IInspectable
-    implements IVectorView<IXmlNode>, IIterable<IXmlNode> {
+    implements IVectorView<IXmlNode?>, IIterable<IXmlNode?> {
   // vtable begins at 6, is 8 entries long.
   IXmlNamedNodeMap.fromPtr(super.ptr);
 
@@ -73,7 +73,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -105,7 +105,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -138,7 +138,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -170,7 +170,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -206,7 +206,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -242,7 +242,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -275,7 +275,7 @@ class IXmlNamedNodeMap extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -283,34 +283,34 @@ class IXmlNamedNodeMap extends IInspectable
     return IXmlNode.fromPtr(retValuePtr);
   }
 
-  late final _iVectorView = IVectorView<IXmlNode>.fromPtr(
+  late final _iVectorView = IVectorView<IXmlNode?>.fromPtr(
       toInterface('{139d959e-e7b5-5cb6-a596-4b544478da9b}'),
       creator: IXmlNode.fromPtr,
       iterableIid: '{f1146ffc-8c92-56e8-93f1-711f86722633}');
 
   @override
-  IXmlNode getAt(int index) => _iVectorView.getAt(index);
+  IXmlNode? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(IXmlNode value, Pointer<Uint32> index) =>
+  bool indexOf(IXmlNode? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<IXmlNode> items) =>
+  int getMany(int startIndex, int itemsSize, List<IXmlNode?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<IXmlNode> first() => _iVectorView.first();
+  IIterator<IXmlNode?> first() => _iVectorView.first();
 
   @override
-  List<IXmlNode> toList() => _iVectorView.toList();
+  List<IXmlNode?> toList() => _iVectorView.toList();
 
   @override
-  IXmlNode operator [](int index) => _iVectorView[index];
+  IXmlNode? operator [](int index) => _iVectorView[index];
 
   @override
-  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
+  List<IXmlNode?> operator +(List<IXmlNode?> other) => toList() + other;
 }

--- a/packages/windows_data/lib/src/xml/dom/ixmlnode.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnode.dart
@@ -58,7 +58,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -151,7 +151,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -202,7 +202,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -230,7 +230,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -258,7 +258,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -286,7 +286,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -361,7 +361,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -399,7 +399,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -437,7 +437,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -469,7 +469,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -501,7 +501,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -530,7 +530,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -558,7 +558,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -586,7 +586,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -614,7 +614,7 @@ class IXmlNode extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/xml/dom/ixmlnodelist.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnodelist.dart
@@ -21,7 +21,7 @@ import 'ixmlnode.dart';
 const IID_IXmlNodeList = '{8c60ad77-83a4-4ec1-9c54-7ba429e13da6}';
 
 class IXmlNodeList extends IInspectable
-    implements IVectorView<IXmlNode>, IIterable<IXmlNode> {
+    implements IVectorView<IXmlNode?>, IIterable<IXmlNode?> {
   // vtable begins at 6, is 2 entries long.
   IXmlNodeList.fromPtr(super.ptr);
 
@@ -73,7 +73,7 @@ class IXmlNodeList extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -81,34 +81,34 @@ class IXmlNodeList extends IInspectable
     return IXmlNode.fromPtr(retValuePtr);
   }
 
-  late final _iVectorView = IVectorView<IXmlNode>.fromPtr(
+  late final _iVectorView = IVectorView<IXmlNode?>.fromPtr(
       toInterface('{139d959e-e7b5-5cb6-a596-4b544478da9b}'),
       creator: IXmlNode.fromPtr,
       iterableIid: '{f1146ffc-8c92-56e8-93f1-711f86722633}');
 
   @override
-  IXmlNode getAt(int index) => _iVectorView.getAt(index);
+  IXmlNode? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(IXmlNode value, Pointer<Uint32> index) =>
+  bool indexOf(IXmlNode? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<IXmlNode> items) =>
+  int getMany(int startIndex, int itemsSize, List<IXmlNode?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<IXmlNode> first() => _iVectorView.first();
+  IIterator<IXmlNode?> first() => _iVectorView.first();
 
   @override
-  List<IXmlNode> toList() => _iVectorView.toList();
+  List<IXmlNode?> toList() => _iVectorView.toList();
 
   @override
-  IXmlNode operator [](int index) => _iVectorView[index];
+  IXmlNode? operator [](int index) => _iVectorView[index];
 
   @override
-  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
+  List<IXmlNode?> operator +(List<IXmlNode?> other) => toList() + other;
 }

--- a/packages/windows_data/lib/src/xml/dom/ixmlnodeselector.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnodeselector.dart
@@ -52,7 +52,7 @@ class IXmlNodeSelector extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -118,7 +118,7 @@ class IXmlNodeSelector extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/xml/dom/ixmltext.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmltext.dart
@@ -60,7 +60,7 @@ class IXmlText extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_data/lib/src/xml/dom/xmlnamednodemap.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlnamednodemap.dart
@@ -20,7 +20,7 @@ import 'ixmlnode.dart';
 
 /// Encapsulates iteration through the collection of attribute nodes.
 class XmlNamedNodeMap extends IInspectable
-    implements IXmlNamedNodeMap, IVectorView<IXmlNode>, IIterable<IXmlNode> {
+    implements IXmlNamedNodeMap, IVectorView<IXmlNode?>, IIterable<IXmlNode?> {
   XmlNamedNodeMap.fromPtr(super.ptr);
 
   late final _iXmlNamedNodeMap = IXmlNamedNodeMap.from(this);
@@ -54,34 +54,34 @@ class XmlNamedNodeMap extends IInspectable
   IXmlNode? setNamedItemNS(IXmlNode? node) =>
       _iXmlNamedNodeMap.setNamedItemNS(node);
 
-  late final _iVectorView = IVectorView<IXmlNode>.fromPtr(
+  late final _iVectorView = IVectorView<IXmlNode?>.fromPtr(
       toInterface('{139d959e-e7b5-5cb6-a596-4b544478da9b}'),
       creator: IXmlNode.fromPtr,
       iterableIid: '{f1146ffc-8c92-56e8-93f1-711f86722633}');
 
   @override
-  IXmlNode getAt(int index) => _iVectorView.getAt(index);
+  IXmlNode? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(IXmlNode value, Pointer<Uint32> index) =>
+  bool indexOf(IXmlNode? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<IXmlNode> items) =>
+  int getMany(int startIndex, int itemsSize, List<IXmlNode?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<IXmlNode> first() => _iVectorView.first();
+  IIterator<IXmlNode?> first() => _iVectorView.first();
 
   @override
-  List<IXmlNode> toList() => _iVectorView.toList();
+  List<IXmlNode?> toList() => _iVectorView.toList();
 
   @override
-  IXmlNode operator [](int index) => _iVectorView[index];
+  IXmlNode? operator [](int index) => _iVectorView[index];
 
   @override
-  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
+  List<IXmlNode?> operator +(List<IXmlNode?> other) => toList() + other;
 }

--- a/packages/windows_data/lib/src/xml/dom/xmlnodelist.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlnodelist.dart
@@ -20,7 +20,7 @@ import 'ixmlnodelist.dart';
 
 /// Describes a collection of nodes.
 class XmlNodeList extends IInspectable
-    implements IXmlNodeList, IVectorView<IXmlNode>, IIterable<IXmlNode> {
+    implements IXmlNodeList, IVectorView<IXmlNode?>, IIterable<IXmlNode?> {
   XmlNodeList.fromPtr(super.ptr);
 
   late final _iXmlNodeList = IXmlNodeList.from(this);
@@ -31,34 +31,34 @@ class XmlNodeList extends IInspectable
   @override
   IXmlNode? item(int index) => _iXmlNodeList.item(index);
 
-  late final _iVectorView = IVectorView<IXmlNode>.fromPtr(
+  late final _iVectorView = IVectorView<IXmlNode?>.fromPtr(
       toInterface('{139d959e-e7b5-5cb6-a596-4b544478da9b}'),
       creator: IXmlNode.fromPtr,
       iterableIid: '{f1146ffc-8c92-56e8-93f1-711f86722633}');
 
   @override
-  IXmlNode getAt(int index) => _iVectorView.getAt(index);
+  IXmlNode? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(IXmlNode value, Pointer<Uint32> index) =>
+  bool indexOf(IXmlNode? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<IXmlNode> items) =>
+  int getMany(int startIndex, int itemsSize, List<IXmlNode?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<IXmlNode> first() => _iVectorView.first();
+  IIterator<IXmlNode?> first() => _iVectorView.first();
 
   @override
-  List<IXmlNode> toList() => _iVectorView.toList();
+  List<IXmlNode?> toList() => _iVectorView.toList();
 
   @override
-  IXmlNode operator [](int index) => _iVectorView[index];
+  IXmlNode? operator [](int index) => _iVectorView[index];
 
   @override
-  List<IXmlNode> operator +(List<IXmlNode> other) => toList() + other;
+  List<IXmlNode?> operator +(List<IXmlNode?> other) => toList() + other;
 }

--- a/packages/windows_devices/example/audio.dart
+++ b/packages/windows_devices/example/audio.dart
@@ -4,13 +4,18 @@
 
 import 'package:windows_devices/windows_devices.dart';
 
+void printAudioDevice(DeviceInformation? device) {
+  if (device == null) return;
+  final DeviceInformation(:id, :name, :isDefault, :isEnabled) = device;
+  print('Device name: $name, isDefault: $isDefault, isEnabled: $isEnabled, '
+      'ID: $id');
+}
+
 void main() async {
   // Identify all audio rendering devices on the system
   final audioRenderingDevices =
       await DeviceInformation.findAllAsyncDeviceClass(DeviceClass.audioRender);
-  for (final DeviceInformation(:name, :isDefault, :isEnabled, :id)
-      in audioRenderingDevices.toList()) {
-    print(
-        'Device name: $name, isDefault: $isDefault, isEnabled: $isEnabled, ID: $id');
+  for (final device in audioRenderingDevices.toList()) {
+    printAudioDevice(device);
   }
 }

--- a/packages/windows_devices/example/battery.dart
+++ b/packages/windows_devices/example/battery.dart
@@ -6,20 +6,18 @@ import 'package:windows_devices/windows_devices.dart';
 
 void printBatteryReport(Battery? battery) {
   final report = battery?.getReport();
-  if (report
-      case BatteryReport(
-        :final chargeRateInMilliwatts,
-        :final designCapacityInMilliwattHours,
-        :final fullChargeCapacityInMilliwattHours,
-        :final remainingCapacityInMilliwattHours
-      )) {
-    print('Charge rate (mW): $chargeRateInMilliwatts');
-    print('Design energy capacity (mWh): $designCapacityInMilliwattHours');
-    print(
-        'Fully-charged energy capacity (mWh): $fullChargeCapacityInMilliwattHours');
-    print(
-        'Remaining energy capacity (mWh): $remainingCapacityInMilliwattHours');
-  }
+  if (report == null) return;
+  final BatteryReport(
+    :chargeRateInMilliwatts,
+    :designCapacityInMilliwattHours,
+    :fullChargeCapacityInMilliwattHours,
+    :remainingCapacityInMilliwattHours
+  ) = report;
+  print('Charge rate (mW): $chargeRateInMilliwatts');
+  print('Design energy capacity (mWh): $designCapacityInMilliwattHours');
+  print(
+      'Fully-charged energy capacity (mWh): $fullChargeCapacityInMilliwattHours');
+  print('Remaining energy capacity (mWh): $remainingCapacityInMilliwattHours');
 }
 
 void main() async {
@@ -28,7 +26,9 @@ void main() async {
   final batteryDevices =
       await DeviceInformation.findAllAsyncAqsFilter(deviceSelector);
   for (final batteryDevice in batteryDevices.toList()) {
-    final battery = await Battery.fromIdAsync(batteryDevice.id);
-    printBatteryReport(battery);
+    if (batteryDevice != null) {
+      final battery = await Battery.fromIdAsync(batteryDevice.id);
+      printBatteryReport(battery);
+    }
   }
 }

--- a/packages/windows_devices/example/display.dart
+++ b/packages/windows_devices/example/display.dart
@@ -5,7 +5,8 @@
 import 'package:windows_devices/windows_devices.dart';
 import 'package:windows_graphics/windows_graphics.dart';
 
-void printMonitorSpecs(DisplayMonitor monitor) {
+void printMonitorSpecs(DisplayMonitor? monitor) {
+  if (monitor == null) return;
   print('Display name: ${monitor.displayName}');
   print('Monitor size: '
       '${monitor.physicalSizeInInches?.width.toStringAsFixed(1)}in x '
@@ -29,8 +30,8 @@ void main() async {
   final deviceInformationCollection =
       await DeviceInformation.findAllAsyncAqsFilter(deviceSelector);
   for (final device in deviceInformationCollection.toList()) {
-    final monitor = await DisplayMonitor.fromInterfaceIdAsync(device.id);
-    if (monitor != null) {
+    if (device != null) {
+      final monitor = await DisplayMonitor.fromInterfaceIdAsync(device.id);
       printMonitorSpecs(monitor);
     }
   }

--- a/packages/windows_devices/lib/src/display/idisplaymonitor.dart
+++ b/packages/windows_devices/lib/src/display/idisplaymonitor.dart
@@ -272,7 +272,7 @@ class IDisplayMonitor extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/deviceinformationcollection.dart
+++ b/packages/windows_devices/lib/src/enumeration/deviceinformationcollection.dart
@@ -19,38 +19,38 @@ import 'deviceinformation.dart';
 
 /// Represents a collection of DeviceInformation objects.
 class DeviceInformationCollection extends IInspectable
-    implements IVectorView<DeviceInformation>, IIterable<DeviceInformation> {
+    implements IVectorView<DeviceInformation?>, IIterable<DeviceInformation?> {
   DeviceInformationCollection.fromPtr(super.ptr);
 
-  late final _iVectorView = IVectorView<DeviceInformation>.fromPtr(
+  late final _iVectorView = IVectorView<DeviceInformation?>.fromPtr(
       toInterface('{e170688f-3495-5bf6-aab5-9cac17e0f10f}'),
       creator: DeviceInformation.fromPtr,
       iterableIid: '{dd9f8a5d-ec98-5f4b-a3ea-9c8b5ad53c4b}');
 
   @override
-  DeviceInformation getAt(int index) => _iVectorView.getAt(index);
+  DeviceInformation? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(DeviceInformation value, Pointer<Uint32> index) =>
+  bool indexOf(DeviceInformation? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<DeviceInformation> items) =>
+  int getMany(int startIndex, int itemsSize, List<DeviceInformation?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<DeviceInformation> first() => _iVectorView.first();
+  IIterator<DeviceInformation?> first() => _iVectorView.first();
 
   @override
-  List<DeviceInformation> toList() => _iVectorView.toList();
+  List<DeviceInformation?> toList() => _iVectorView.toList();
 
   @override
-  DeviceInformation operator [](int index) => _iVectorView[index];
+  DeviceInformation? operator [](int index) => _iVectorView[index];
 
   @override
-  List<DeviceInformation> operator +(List<DeviceInformation> other) =>
+  List<DeviceInformation?> operator +(List<DeviceInformation?> other) =>
       toList() + other;
 }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformation.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformation.dart
@@ -147,7 +147,7 @@ class IDeviceInformation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformation2.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformation2.dart
@@ -73,7 +73,7 @@ class IDeviceInformation2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationpairing2.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationpairing2.dart
@@ -76,7 +76,7 @@ class IDeviceInformationPairing2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics.dart
@@ -257,7 +257,7 @@ class IDeviceInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -289,7 +289,7 @@ class IDeviceInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -321,7 +321,7 @@ class IDeviceInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -367,7 +367,7 @@ class IDeviceInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics2.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationstatics2.dart
@@ -198,7 +198,7 @@ class IDeviceInformationStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
@@ -52,7 +52,7 @@ class IDevicePicker extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -80,7 +80,7 @@ class IDevicePicker extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/enumeration/idevicewatcher2.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicewatcher2.dart
@@ -61,7 +61,7 @@ class IDeviceWatcher2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/geolocator.dart
+++ b/packages/windows_devices/lib/src/geolocation/geolocator.dart
@@ -39,13 +39,13 @@ class Geolocator extends IInspectable
               IGeolocatorStatics.fromPtr, _className, IID_IGeolocatorStatics)
           .requestAccessAsync();
 
-  static Future<List<Geoposition>> getGeopositionHistoryAsync(
+  static Future<List<Geoposition?>> getGeopositionHistoryAsync(
           DateTime startTime) =>
       createActivationFactory(
               IGeolocatorStatics.fromPtr, _className, IID_IGeolocatorStatics)
           .getGeopositionHistoryAsync(startTime);
 
-  static Future<List<Geoposition>> getGeopositionHistoryWithDurationAsync(
+  static Future<List<Geoposition?>> getGeopositionHistoryWithDurationAsync(
           DateTime startTime, Duration duration) =>
       createActivationFactory(
               IGeolocatorStatics.fromPtr, _className, IID_IGeolocatorStatics)

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinate.dart
@@ -99,7 +99,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -153,7 +153,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -183,7 +183,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -213,7 +213,7 @@ class IGeocoordinate extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata.dart
@@ -47,7 +47,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -77,7 +77,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -107,7 +107,7 @@ class IGeocoordinateSatelliteData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatesatellitedata2.dart
@@ -47,7 +47,7 @@ class IGeocoordinateSatelliteData2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -77,7 +77,7 @@ class IGeocoordinateSatelliteData2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpoint.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpoint.dart
@@ -48,7 +48,7 @@ class IGeocoordinateWithPoint extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositiondata.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositiondata.dart
@@ -76,7 +76,7 @@ class IGeocoordinateWithPositionData extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeocoordinatewithpositionsourcetimestamp.dart
@@ -48,7 +48,7 @@ class IGeocoordinateWithPositionSourceTimestamp extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics.dart
@@ -54,7 +54,7 @@ class IGeolocatorStatics extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<List<Geoposition>> getGeopositionHistoryAsync(DateTime startTime) {
+  Future<List<Geoposition?>> getGeopositionHistoryAsync(DateTime startTime) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -75,7 +75,7 @@ class IGeolocatorStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<Geoposition>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<Geoposition?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: Geoposition.fromPtr,
@@ -83,7 +83,7 @@ class IGeolocatorStatics extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<Geoposition>> getGeopositionHistoryWithDurationAsync(
+  Future<List<Geoposition?>> getGeopositionHistoryWithDurationAsync(
       DateTime startTime, Duration duration) {
     final retValuePtr = calloc<COMObject>();
 
@@ -105,7 +105,7 @@ class IGeolocatorStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<Geoposition>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<Geoposition?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: Geoposition.fromPtr,

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorstatics2.dart
@@ -88,7 +88,7 @@ class IGeolocatorStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeolocatorwithscalaraccuracy.dart
@@ -54,7 +54,7 @@ class IGeolocatorWithScalarAccuracy extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeoposition.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeoposition.dart
@@ -48,7 +48,7 @@ class IGeoposition extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -76,7 +76,7 @@ class IGeoposition extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/geolocation/igeoposition2.dart
+++ b/packages/windows_devices/lib/src/geolocation/igeoposition2.dart
@@ -50,7 +50,7 @@ class IGeoposition2 extends IInspectable implements IGeoposition {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/power/ibattery.dart
+++ b/packages/windows_devices/lib/src/power/ibattery.dart
@@ -73,7 +73,7 @@ class IBattery extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/power/ibatteryreport.dart
+++ b/packages/windows_devices/lib/src/power/ibatteryreport.dart
@@ -46,7 +46,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -76,7 +76,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -106,7 +106,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -136,7 +136,7 @@ class IBatteryReport extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/lib/src/power/ibatterystatics.dart
+++ b/packages/windows_devices/lib/src/power/ibatterystatics.dart
@@ -47,7 +47,7 @@ class IBatteryStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_devices/test/collections_test.dart
+++ b/packages/windows_devices/test/collections_test.dart
@@ -41,6 +41,7 @@ void main() {
       final vector = getVector()
         ..append(DeviceClass.audioCapture)
         ..append(DeviceClass.audioRender);
+      expect(vector.size, equals(2));
       expect(vector.getAt(0), equals(DeviceClass.audioCapture));
       expect(vector.getAt(1), equals(DeviceClass.audioRender));
     });

--- a/packages/windows_foundation/lib/src/collections/iiterable.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterable.dart
@@ -22,8 +22,8 @@ interface class IIterable<T> extends IInspectable {
 
   /// Creates an instance of [IIterable] from the given [ptr].
   ///
-  /// [T] must be of type `bool`, `double`, `Guid`, `int`, `String`, `Uri`,
-  /// `IInspectable` (e.g.`StorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  /// [T] must be of type `bool`, `double`, `Guid`, `int`, `String`, `Uri?`,
+  /// `IInspectable?` (e.g.`StorageFile?`) or `WinRTEnum` (e.g. `DeviceClass`).
   ///
   /// [doubleType] must be specified if [T] is `double`.
   /// ```dart
@@ -36,9 +36,9 @@ interface class IIterable<T> extends IInspectable {
   /// final iterable = IIterable<int>.fromPtr(ptr, intType: IntType.uint64);
   /// ```
   ///
-  /// [creator] must be specified if [T] is `IInspectable`.
+  /// [creator] must be specified if [T] is `IInspectable?`.
   /// ```dart
-  /// final iterable = IIterable<StorageFile>.fromPtr(ptr,
+  /// final iterable = IIterable<StorageFile?>.fromPtr(ptr,
   ///     creator: StorageFile.fromPtr);
   /// ```
   ///

--- a/packages/windows_foundation/lib/src/collections/iiterator.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterator.dart
@@ -19,8 +19,8 @@ abstract interface class IIterator<T> extends IInspectable {
 
   /// Creates an instance of [IIterator] from the given [ptr].
   ///
-  /// [T] must be of type `bool`, `double` `Guid`, `int`, `String`, `Uri`,
-  /// `IInspectable` (e.g.`StorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  /// [T] must be of type `bool`, `double` `Guid`, `int`, `String`, `Uri?`,
+  /// `IInspectable?` (e.g.`StorageFile?`) or `WinRTEnum` (e.g. `DeviceClass`).
   ///
   /// [doubleType] must be specified if [T] is `double`.
   /// ```dart
@@ -33,9 +33,9 @@ abstract interface class IIterator<T> extends IInspectable {
   /// final iterator = IIterator<int>.fromPtr(ptr, intType: IntType.uint64);
   /// ```
   ///
-  /// [creator] must be specified if [T] is `IInspectable`.
+  /// [creator] must be specified if [T] is `IInspectable?`.
   /// ```dart
-  /// final iterator = IIterator<StorageFile>.fromPtr(ptr,
+  /// final iterator = IIterator<StorageFile?>.fromPtr(ptr,
   ///     creator: StorageFile.fromPtr);
   /// ```
   ///
@@ -83,7 +83,7 @@ abstract interface class IIterator<T> extends IInspectable {
     }
 
     if (T == String) return _IIteratorString.fromPtr(ptr) as IIterator<T>;
-    if (T == Uri) return _IIteratorUri.fromPtr(ptr) as IIterator<T>;
+    if (isSubtype<T, Uri>()) return _IIteratorUri.fromPtr(ptr) as IIterator<T>;
 
     if (isSubtypeOfWinRTEnum<T>()) {
       if (enumCreator == null) throw ArgumentError.notNull('enumCreator');

--- a/packages/windows_foundation/lib/src/collections/iiterator_part.dart
+++ b/packages/windows_foundation/lib/src/collections/iiterator_part.dart
@@ -858,11 +858,11 @@ final class _IIteratorUint64 extends IIterator<int> {
   }
 }
 
-final class _IIteratorUri extends IIterator<Uri> {
+final class _IIteratorUri extends IIterator<Uri?> {
   _IIteratorUri.fromPtr(super.ptr);
 
   @override
-  Uri get current {
+  Uri? get current {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -882,12 +882,17 @@ final class _IIteratorUri extends IIterator<Uri> {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.isNull) {
+      free(retValuePtr);
+      return null;
+    }
+
     final winrtUri = retValuePtr.toWinRTUri();
     return winrtUri.toDartUri();
   }
 
   @override
-  int getMany(int itemsSize, List<Uri> items) {
+  int getMany(int itemsSize, List<Uri?> items) {
     final retValuePtr = calloc<Uint32>();
 
     try {

--- a/packages/windows_foundation/lib/src/collections/ikeyvaluepair_part.dart
+++ b/packages/windows_foundation/lib/src/collections/ikeyvaluepair_part.dart
@@ -60,7 +60,7 @@ final class _IKeyValuePairGuidInspectable<V> extends IKeyValuePair<Guid, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -118,7 +118,7 @@ final class _IKeyValuePairGuidObject extends IKeyValuePair<Guid, Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -178,7 +178,7 @@ final class _IKeyValuePairInt16Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -238,7 +238,7 @@ final class _IKeyValuePairInt32Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -298,7 +298,7 @@ final class _IKeyValuePairInt64Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -360,7 +360,7 @@ final class _IKeyValuePairStringInspectable<V>
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -419,7 +419,7 @@ final class _IKeyValuePairStringObject extends IKeyValuePair<String, Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -651,7 +651,7 @@ final class _IKeyValuePairUint8Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -711,7 +711,7 @@ final class _IKeyValuePairUint16Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -771,7 +771,7 @@ final class _IKeyValuePairUint32Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -831,7 +831,7 @@ final class _IKeyValuePairUint64Inspectable<V> extends IKeyValuePair<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -894,7 +894,7 @@ final class _IKeyValuePairWinRTEnumInspectable<K, V>
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -957,7 +957,7 @@ final class _IKeyValuePairWinRTFlagsEnumInspectable<K, V>
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }

--- a/packages/windows_foundation/lib/src/collections/imap_part.dart
+++ b/packages/windows_foundation/lib/src/collections/imap_part.dart
@@ -41,7 +41,7 @@ final class _IMapGuidInspectable<V> extends IMap<Guid, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -164,7 +164,7 @@ final class _IMapGuidObject extends IMap<Guid, Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -286,7 +286,7 @@ final class _IMapInt16Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -398,7 +398,7 @@ final class _IMapInt32Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -510,7 +510,7 @@ final class _IMapInt64Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -625,7 +625,7 @@ final class _IMapStringInspectable<V> extends IMap<String, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -748,7 +748,7 @@ final class _IMapStringObject extends IMap<String, Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -1220,7 +1220,7 @@ final class _IMapUint8Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -1332,7 +1332,7 @@ final class _IMapUint16Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -1444,7 +1444,7 @@ final class _IMapUint32Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -1556,7 +1556,7 @@ final class _IMapUint64Inspectable<V> extends IMap<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -1671,7 +1671,7 @@ final class _IMapWinRTEnumInspectable<K, V> extends IMap<K, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -1786,7 +1786,7 @@ final class _IMapWinRTFlagsEnumInspectable<K, V> extends IMap<K, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }

--- a/packages/windows_foundation/lib/src/collections/imapview_part.dart
+++ b/packages/windows_foundation/lib/src/collections/imapview_part.dart
@@ -41,7 +41,7 @@ final class _IMapViewGuidInspectable<V> extends IMapView<Guid, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -108,7 +108,7 @@ final class _IMapViewGuidObject extends IMapView<Guid, Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -176,7 +176,7 @@ final class _IMapViewInt16Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -240,7 +240,7 @@ final class _IMapViewInt32Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -304,7 +304,7 @@ final class _IMapViewInt64Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -371,7 +371,7 @@ final class _IMapViewStringInspectable<V> extends IMapView<String, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -438,7 +438,7 @@ final class _IMapViewStringObject extends IMapView<String, Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -707,7 +707,7 @@ final class _IMapViewUint8Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -771,7 +771,7 @@ final class _IMapViewUint16Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -835,7 +835,7 @@ final class _IMapViewUint32Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -899,7 +899,7 @@ final class _IMapViewUint64Inspectable<V> extends IMapView<int, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -966,7 +966,7 @@ final class _IMapViewWinRTEnumInspectable<K, V> extends IMapView<K, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }
@@ -1033,7 +1033,7 @@ final class _IMapViewWinRTFlagsEnumInspectable<K, V> extends IMapView<K, V> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as V;
     }

--- a/packages/windows_foundation/lib/src/collections/ivector.dart
+++ b/packages/windows_foundation/lib/src/collections/ivector.dart
@@ -44,8 +44,8 @@ abstract interface class IVector<T> extends IInspectable
   /// [iterableIid] must be the IID of the `IIterable<T>` interface (e.g.
   /// `'{9ac00304-83ea-5688-87b6-ae38aab65d0b}'`).
   ///
-  /// [T] must be of type `bool`, `double`, `Guid`, `int`, `String`, `Uri`,
-  /// `IInspectable` (e.g.`StorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  /// [T] must be of type `bool`, `double`, `Guid`, `int`, `String`, `Uri?`,
+  /// `IInspectable?` (e.g.`StorageFile?`) or `WinRTEnum` (e.g. `DeviceClass`).
   ///
   /// [doubleType] must be specified if [T] is `double`.
   /// ```dart
@@ -61,9 +61,9 @@ abstract interface class IVector<T> extends IInspectable
   ///     iterableIid: '{4b3a3229-7995-5f3c-b248-6c1f7e664f01}');
   /// ```
   ///
-  /// [creator] must be specified if [T] is `IInspectable`.
+  /// [creator] must be specified if [T] is `IInspectable?`.
   /// ```dart
-  /// final vector = IVector<StorageFile>.fromPtr(ptr,
+  /// final vector = IVector<StorageFile?>.fromPtr(ptr,
   ///     creator: StorageFile.fromPtr,
   ///     iterableIid: '{9ac00304-83ea-5688-87b6-ae38aab65d0b}');
   /// ```
@@ -133,7 +133,7 @@ abstract interface class IVector<T> extends IInspectable
           as IVector<T>;
     }
 
-    if (T == Uri) {
+    if (isSubtype<T, Uri>()) {
       return _IVectorUri.fromPtr(ptr, iterableIid: iterableIid) as IVector<T>;
     }
 

--- a/packages/windows_foundation/lib/src/collections/ivector_part.dart
+++ b/packages/windows_foundation/lib/src/collections/ivector_part.dart
@@ -2348,11 +2348,11 @@ final class _IVectorUint64 extends IVector<int> {
   }
 }
 
-final class _IVectorUri extends IVector<Uri> {
+final class _IVectorUri extends IVector<Uri?> {
   _IVectorUri.fromPtr(super.ptr, {required super.iterableIid});
 
   @override
-  Uri getAt(int index) {
+  Uri? getAt(int index) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -2373,16 +2373,21 @@ final class _IVectorUri extends IVector<Uri> {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.isNull) {
+      free(retValuePtr);
+      return null;
+    }
+
     final winrtUri = retValuePtr.toWinRTUri();
     return winrtUri.toDartUri();
   }
 
   @override
-  bool indexOf(Uri value, Pointer<Uint32> index) {
+  bool indexOf(Uri? value, Pointer<Uint32> index) {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final valueUri = value.toWinRTUri();
+      final valueUri = value?.toWinRTUri();
 
       final hr = ptr.ref.vtable
               .elementAt(9)
@@ -2398,7 +2403,10 @@ final class _IVectorUri extends IVector<Uri> {
               .asFunction<
                   int Function(VTablePointer lpVtbl, VTablePointer value,
                       Pointer<Uint32> index, Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl, valueUri.ptr.ref.lpVtbl, index, retValuePtr);
+          ptr.ref.lpVtbl,
+          valueUri == null ? nullptr : valueUri.ptr.ref.lpVtbl,
+          index,
+          retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -2409,8 +2417,8 @@ final class _IVectorUri extends IVector<Uri> {
   }
 
   @override
-  void setAt(int index, Uri value) {
-    final valueUri = value.toWinRTUri();
+  void setAt(int index, Uri? value) {
+    final valueUri = value?.toWinRTUri();
 
     final hr = ptr.ref.vtable
             .elementAt(10)
@@ -2423,14 +2431,16 @@ final class _IVectorUri extends IVector<Uri> {
             .asFunction<
                 int Function(
                     VTablePointer lpVtbl, int index, VTablePointer value)>()(
-        ptr.ref.lpVtbl, index, valueUri.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl,
+        index,
+        valueUri == null ? nullptr : valueUri.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   @override
-  void insertAt(int index, Uri value) {
-    final valueUri = value.toWinRTUri();
+  void insertAt(int index, Uri? value) {
+    final valueUri = value?.toWinRTUri();
 
     final hr = ptr.ref.vtable
             .elementAt(11)
@@ -2443,14 +2453,16 @@ final class _IVectorUri extends IVector<Uri> {
             .asFunction<
                 int Function(
                     VTablePointer lpVtbl, int index, VTablePointer value)>()(
-        ptr.ref.lpVtbl, index, valueUri.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl,
+        index,
+        valueUri == null ? nullptr : valueUri.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   @override
-  void append(Uri value) {
-    final valueUri = value.toWinRTUri();
+  void append(Uri? value) {
+    final valueUri = value?.toWinRTUri();
 
     final hr = ptr.ref.vtable
             .elementAt(13)
@@ -2462,13 +2474,13 @@ final class _IVectorUri extends IVector<Uri> {
             .value
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer value)>()(
-        ptr.ref.lpVtbl, valueUri.ptr.ref.lpVtbl);
+        ptr.ref.lpVtbl, valueUri == null ? nullptr : valueUri.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
   @override
-  int getMany(int startIndex, int itemsSize, List<Uri> items) {
+  int getMany(int startIndex, int itemsSize, List<Uri?> items) {
     final retValuePtr = calloc<Uint32>();
 
     try {
@@ -2509,11 +2521,11 @@ final class _IVectorUri extends IVector<Uri> {
   }
 
   @override
-  void replaceAll(List<Uri> items) {
+  void replaceAll(List<Uri?> items) {
     final pItemsArray = calloc<COMObject>(items.length);
     for (var i = 0; i < items.length; i++) {
-      final itemsWinrtUri = items.elementAt(i).toWinRTUri();
-      pItemsArray[i] = itemsWinrtUri.ptr.ref;
+      pItemsArray[i] =
+          items.elementAt(i)?.toWinRTUri().ptr.ref ?? calloc<COMObject>().ref;
     }
 
     final hr = ptr.ref.vtable

--- a/packages/windows_foundation/lib/src/collections/ivectorview.dart
+++ b/packages/windows_foundation/lib/src/collections/ivectorview.dart
@@ -44,8 +44,8 @@ abstract interface class IVectorView<T> extends IInspectable
   /// [iterableIid] must be the IID of the `IIterable<T>` interface (e.g.
   /// `'{9ac00304-83ea-5688-87b6-ae38aab65d0b}'`).
   ///
-  /// [T] must be of type `bool`, `double` `Guid`, `int`, `String`, `Uri`,
-  /// `IInspectable` (e.g.`StorageFile`) or `WinRTEnum` (e.g. `DeviceClass`).
+  /// [T] must be of type `bool`, `double` `Guid`, `int`, `String`, `Uri?`,
+  /// `IInspectable?` (e.g.`StorageFile?`) or `WinRTEnum` (e.g. `DeviceClass`).
   ///
   /// [doubleType] must be specified if [T] is `double`.
   /// ```dart
@@ -61,9 +61,9 @@ abstract interface class IVectorView<T> extends IInspectable
   ///     iterableIid: '{4b3a3229-7995-5f3c-b248-6c1f7e664f01}');
   /// ```
   ///
-  /// [creator] must be specified if [T] is `IInspectable`.
+  /// [creator] must be specified if [T] is `IInspectable?`.
   /// ```dart
-  /// final vectorView = IVectorView<StorageFile>.fromPtr(ptr,
+  /// final vectorView = IVectorView<StorageFile?>.fromPtr(ptr,
   ///     creator: StorageFile.fromPtr,
   ///     iterableIid: '{9ac00304-83ea-5688-87b6-ae38aab65d0b}');
   /// ```
@@ -135,7 +135,7 @@ abstract interface class IVectorView<T> extends IInspectable
           as IVectorView<T>;
     }
 
-    if (T == Uri) {
+    if (isSubtype<T, Uri>()) {
       return _IVectorViewUri.fromPtr(ptr, iterableIid: iterableIid)
           as IVectorView<T>;
     }

--- a/packages/windows_foundation/lib/src/collections/ivectorview_part.dart
+++ b/packages/windows_foundation/lib/src/collections/ivectorview_part.dart
@@ -1345,11 +1345,11 @@ final class _IVectorViewUint64 extends IVectorView<int> {
   }
 }
 
-final class _IVectorViewUri extends IVectorView<Uri> {
+final class _IVectorViewUri extends IVectorView<Uri?> {
   _IVectorViewUri.fromPtr(super.ptr, {required super.iterableIid});
 
   @override
-  Uri getAt(int index) {
+  Uri? getAt(int index) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -1370,16 +1370,21 @@ final class _IVectorViewUri extends IVectorView<Uri> {
       throw WindowsException(hr);
     }
 
+    if (retValuePtr.isNull) {
+      free(retValuePtr);
+      return null;
+    }
+
     final winrtUri = retValuePtr.toWinRTUri();
     return winrtUri.toDartUri();
   }
 
   @override
-  bool indexOf(Uri value, Pointer<Uint32> index) {
+  bool indexOf(Uri? value, Pointer<Uint32> index) {
     final retValuePtr = calloc<Bool>();
 
     try {
-      final valueUri = value.toWinRTUri();
+      final valueUri = value?.toWinRTUri();
 
       final hr = ptr.ref.vtable
               .elementAt(8)
@@ -1395,7 +1400,10 @@ final class _IVectorViewUri extends IVectorView<Uri> {
               .asFunction<
                   int Function(VTablePointer lpVtbl, VTablePointer value,
                       Pointer<Uint32> index, Pointer<Bool> retValuePtr)>()(
-          ptr.ref.lpVtbl, valueUri.ptr.ref.lpVtbl, index, retValuePtr);
+          ptr.ref.lpVtbl,
+          valueUri == null ? nullptr : valueUri.ptr.ref.lpVtbl,
+          index,
+          retValuePtr);
 
       if (FAILED(hr)) throw WindowsException(hr);
 
@@ -1406,7 +1414,7 @@ final class _IVectorViewUri extends IVectorView<Uri> {
   }
 
   @override
-  int getMany(int startIndex, int itemsSize, List<Uri> items) {
+  int getMany(int startIndex, int itemsSize, List<Uri?> items) {
     final retValuePtr = calloc<Uint32>();
 
     try {

--- a/packages/windows_foundation/lib/src/iasyncoperation_part.dart
+++ b/packages/windows_foundation/lib/src/iasyncoperation_part.dart
@@ -181,7 +181,7 @@ final class _IAsyncOperationInspectable<TResult>
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as TResult;
     }
@@ -214,7 +214,7 @@ final class _IAsyncOperationObject extends IAsyncOperation<Object?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -247,7 +247,7 @@ final class _IAsyncOperationUri extends IAsyncOperation<Uri?> {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_foundation/lib/src/imemorybuffer.dart
+++ b/packages/windows_foundation/lib/src/imemorybuffer.dart
@@ -50,7 +50,7 @@ class IMemoryBuffer extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_foundation/lib/src/internal/extensions/extensions.dart
+++ b/packages/windows_foundation/lib/src/internal/extensions/extensions.dart
@@ -5,7 +5,7 @@
 export 'async_helpers.dart';
 export 'bool_array.dart';
 export 'boxing_helpers.dart';
-export 'comobject_array.dart';
+export 'comobject_helpers.dart';
 export 'datetime_conversions.dart';
 export 'double_array.dart';
 export 'duration_conversions.dart';

--- a/packages/windows_foundation/lib/src/internal/extensions/ipropertyvalue_helpers.dart
+++ b/packages/windows_foundation/lib/src/internal/extensions/ipropertyvalue_helpers.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
 import 'package:win32/win32.dart';
 
 import '../../ipropertyvalue.dart';
@@ -11,11 +9,12 @@ import '../../point.dart';
 import '../../propertytype.dart';
 import '../../rect.dart';
 import '../../size.dart';
+import 'comobject_helpers.dart';
 
 extension IPropertyValueHelper on IPropertyValue {
   /// Gets the type that is represented as an [IPropertyValue].
   Object? get value {
-    if (ptr.ref.isNull) return null;
+    if (ptr.isNull) return null;
 
     // If the object does not implement the IPropertyValue interface, return it
     // as an IInspectable object.

--- a/packages/windows_foundation/lib/src/internal/extensions/uri_conversions.dart
+++ b/packages/windows_foundation/lib/src/internal/extensions/uri_conversions.dart
@@ -2,17 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'dart:ffi';
-
-import 'package:win32/win32.dart';
-
 import '../../uri.dart' as winrt_uri;
-
-/// @nodoc
-extension COMObjectPointerToWinRTUriConversion on Pointer<COMObject> {
-  /// Creates a WinRT Uri from this Pointer.
-  winrt_uri.Uri toWinRTUri() => winrt_uri.Uri.fromPtr(this);
-}
 
 /// @nodoc
 extension DartUriToWinRTUriConversion on Uri {

--- a/packages/windows_foundation/lib/src/iuriruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iuriruntimeclass.dart
@@ -455,7 +455,7 @@ class IUriRuntimeClass extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iwwwformurldecoderruntimeclass.dart
@@ -26,8 +26,8 @@ const IID_IWwwFormUrlDecoderRuntimeClass =
 
 class IWwwFormUrlDecoderRuntimeClass extends IInspectable
     implements
-        IIterable<IWwwFormUrlDecoderEntry>,
-        IVectorView<IWwwFormUrlDecoderEntry> {
+        IIterable<IWwwFormUrlDecoderEntry?>,
+        IVectorView<IWwwFormUrlDecoderEntry?> {
   // vtable begins at 6, is 1 entries long.
   IWwwFormUrlDecoderRuntimeClass.fromPtr(super.ptr);
 
@@ -65,37 +65,37 @@ class IWwwFormUrlDecoderRuntimeClass extends IInspectable
     }
   }
 
-  late final _iVectorView = IVectorView<IWwwFormUrlDecoderEntry>.fromPtr(
+  late final _iVectorView = IVectorView<IWwwFormUrlDecoderEntry?>.fromPtr(
       toInterface('{b1f00d3b-1f06-5117-93ea-2a0d79116701}'),
       creator: IWwwFormUrlDecoderEntry.fromPtr,
       iterableIid: '{876be83b-7218-5bfb-a169-83152ef7e146}');
 
   @override
-  IWwwFormUrlDecoderEntry getAt(int index) => _iVectorView.getAt(index);
+  IWwwFormUrlDecoderEntry? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(IWwwFormUrlDecoderEntry value, Pointer<Uint32> index) =>
+  bool indexOf(IWwwFormUrlDecoderEntry? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(
-          int startIndex, int itemsSize, List<IWwwFormUrlDecoderEntry> items) =>
+  int getMany(int startIndex, int itemsSize,
+          List<IWwwFormUrlDecoderEntry?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<IWwwFormUrlDecoderEntry> first() => _iVectorView.first();
+  IIterator<IWwwFormUrlDecoderEntry?> first() => _iVectorView.first();
 
   @override
-  List<IWwwFormUrlDecoderEntry> toList() => _iVectorView.toList();
+  List<IWwwFormUrlDecoderEntry?> toList() => _iVectorView.toList();
 
   @override
-  IWwwFormUrlDecoderEntry operator [](int index) => _iVectorView[index];
+  IWwwFormUrlDecoderEntry? operator [](int index) => _iVectorView[index];
 
   @override
-  List<IWwwFormUrlDecoderEntry> operator +(
-          List<IWwwFormUrlDecoderEntry> other) =>
+  List<IWwwFormUrlDecoderEntry?> operator +(
+          List<IWwwFormUrlDecoderEntry?> other) =>
       toList() + other;
 }

--- a/packages/windows_foundation/lib/src/wwwformurldecoder.dart
+++ b/packages/windows_foundation/lib/src/wwwformurldecoder.dart
@@ -27,8 +27,8 @@ import 'iwwwformurldecoderruntimeclassfactory.dart';
 class WwwFormUrlDecoder extends IInspectable
     implements
         IWwwFormUrlDecoderRuntimeClass,
-        IVectorView<IWwwFormUrlDecoderEntry>,
-        IIterable<IWwwFormUrlDecoderEntry> {
+        IVectorView<IWwwFormUrlDecoderEntry?>,
+        IIterable<IWwwFormUrlDecoderEntry?> {
   WwwFormUrlDecoder.fromPtr(super.ptr);
 
   static const _className = 'Windows.Foundation.WwwFormUrlDecoder';
@@ -45,37 +45,37 @@ class WwwFormUrlDecoder extends IInspectable
   String getFirstValueByName(String name) =>
       _iWwwFormUrlDecoderRuntimeClass.getFirstValueByName(name);
 
-  late final _iVectorView = IVectorView<IWwwFormUrlDecoderEntry>.fromPtr(
+  late final _iVectorView = IVectorView<IWwwFormUrlDecoderEntry?>.fromPtr(
       toInterface('{b1f00d3b-1f06-5117-93ea-2a0d79116701}'),
       creator: IWwwFormUrlDecoderEntry.fromPtr,
       iterableIid: '{876be83b-7218-5bfb-a169-83152ef7e146}');
 
   @override
-  IWwwFormUrlDecoderEntry getAt(int index) => _iVectorView.getAt(index);
+  IWwwFormUrlDecoderEntry? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(IWwwFormUrlDecoderEntry value, Pointer<Uint32> index) =>
+  bool indexOf(IWwwFormUrlDecoderEntry? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(
-          int startIndex, int itemsSize, List<IWwwFormUrlDecoderEntry> items) =>
+  int getMany(int startIndex, int itemsSize,
+          List<IWwwFormUrlDecoderEntry?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<IWwwFormUrlDecoderEntry> first() => _iVectorView.first();
+  IIterator<IWwwFormUrlDecoderEntry?> first() => _iVectorView.first();
 
   @override
-  List<IWwwFormUrlDecoderEntry> toList() => _iVectorView.toList();
+  List<IWwwFormUrlDecoderEntry?> toList() => _iVectorView.toList();
 
   @override
-  IWwwFormUrlDecoderEntry operator [](int index) => _iVectorView[index];
+  IWwwFormUrlDecoderEntry? operator [](int index) => _iVectorView[index];
 
   @override
-  List<IWwwFormUrlDecoderEntry> operator +(
-          List<IWwwFormUrlDecoderEntry> other) =>
+  List<IWwwFormUrlDecoderEntry?> operator +(
+          List<IWwwFormUrlDecoderEntry?> other) =>
       toList() + other;
 }

--- a/packages/windows_foundation/test/collections_test.dart
+++ b/packages/windows_foundation/test/collections_test.dart
@@ -784,8 +784,8 @@ void main() {
     });
   });
 
-  group('IVector<Uri>', () {
-    IVector<Uri> getServerUris(Pointer<COMObject> ptr) {
+  group('IVector<Uri?>', () {
+    IVector<Uri?> getServerUris(Pointer<COMObject> ptr) {
       final retValuePtr = calloc<COMObject>();
 
       final hr = ptr.ref.vtable
@@ -801,12 +801,15 @@ void main() {
                       VTablePointer lpVtbl, Pointer<COMObject> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
-      if (FAILED(hr)) throw WindowsException(hr);
+      if (FAILED(hr)) {
+        free(retValuePtr);
+        throw WindowsException(hr);
+      }
 
       return IVector.fromPtr(retValuePtr, iterableIid: IID_IIterable_Uri);
     }
 
-    IVector<Uri> getVector() {
+    IVector<Uri?> getVector() {
       // ignore: constant_identifier_names
       const IID_IVpnPlugInProfile = '{0edf0da4-4f00-4589-8d7b-4bf988f6542c}';
       final object = createObject(IInspectable.new,
@@ -829,17 +832,27 @@ void main() {
     test('getAt returns elements', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
+        ..append(null)
         ..append(Uri.parse('https://dart.dev/docs'));
+      expect(vector.size, equals(3));
       expect(vector.getAt(0), equals(Uri.parse('https://dart.dev/overview')));
-      expect(vector.getAt(1), equals(Uri.parse('https://dart.dev/docs')));
+      expect(vector.getAt(1), isNull);
+      expect(vector.getAt(2), equals(Uri.parse('https://dart.dev/docs')));
     });
 
-    test('getView', () {
+    test('getView returns empty List', () {
+      final vector = getVector();
+      final list = vector.getView();
+      expect(list, isEmpty);
+    });
+
+    test('getView returns elements', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
+        ..append(null)
         ..append(Uri.parse('https://dart.dev/docs'));
       final list = vector.getView();
-      expect(list.length, equals(2));
+      expect(list.length, equals(3));
       expect(() => list..clear(), throwsUnsupportedError);
     });
 
@@ -861,7 +874,7 @@ void main() {
     test('setAt', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'));
+        ..append(null);
       expect(vector.size, equals(2));
       vector.setAt(0, Uri.parse('https://flutter.dev/development'));
       expect(vector.size, equals(2));
@@ -890,13 +903,12 @@ void main() {
       expect(vector.size, equals(2));
       vector.insertAt(0, Uri.parse('https://flutter.dev/development'));
       expect(vector.size, equals(3));
-      vector.insertAt(2, Uri.parse('https://flutter.dev/multi-platform'));
+      vector.insertAt(2, null);
       expect(vector.size, equals(4));
       expect(vector.getAt(0),
           equals(Uri.parse('https://flutter.dev/development')));
       expect(vector.getAt(1), equals(Uri.parse('https://dart.dev/overview')));
-      expect(vector.getAt(2),
-          equals(Uri.parse('https://flutter.dev/multi-platform')));
+      expect(vector.getAt(2), isNull);
       expect(vector.getAt(3), equals(Uri.parse('https://dart.dev/docs')));
     });
 
@@ -916,7 +928,7 @@ void main() {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
         ..append(Uri.parse('https://dart.dev/docs'))
-        ..append(Uri.parse('https://flutter.dev/development'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/multi-platform'));
       expect(vector.size, equals(4));
       vector.removeAt(2);
@@ -938,8 +950,10 @@ void main() {
       expect(vector.size, equals(0));
       vector.append(Uri.parse('https://dart.dev/overview'));
       expect(vector.size, equals(1));
-      vector.append(Uri.parse('https://dart.dev/docs'));
+      vector.append(null);
       expect(vector.size, equals(2));
+      vector.append(Uri.parse('https://dart.dev/docs'));
+      expect(vector.size, equals(3));
     });
 
     test('removeAtEnd throws exception if the vector is empty', () {
@@ -959,8 +973,9 @@ void main() {
     test('clear', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
+        ..append(null)
         ..append(Uri.parse('https://dart.dev/docs'));
-      expect(vector.size, equals(2));
+      expect(vector.size, equals(3));
       vector.clear();
       expect(vector.size, equals(0));
     });
@@ -971,45 +986,45 @@ void main() {
     });
 
     test('getMany returns elements starting from index 0', () {
-      final list = <Uri>[];
+      final list = <Uri?>[];
 
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/development'));
       expect(vector.getMany(0, 3, list), equals(3));
       expect(list.length, equals(3));
       expect(list[0].toString(), equals('https://dart.dev/overview'));
-      expect(list[1].toString(), equals('https://dart.dev/docs'));
+      expect(list[1], isNull);
       expect(list[2].toString(), equals('https://flutter.dev/development'));
     });
 
     test(
         'getMany returns all elements if valueSize is greater than the number '
         'of elements', () {
-      final list = <Uri>[];
+      final list = <Uri?>[];
 
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/development'));
       expect(vector.getMany(0, 5, list), equals(3));
       expect(list.length, equals(3));
       expect(list[0].toString(), equals('https://dart.dev/overview'));
-      expect(list[1].toString(), equals('https://dart.dev/docs'));
+      expect(list[1], isNull);
       expect(list[2].toString(), equals('https://flutter.dev/development'));
     });
 
     test('getMany returns elements starting from index 1', () {
-      final list = <Uri>[];
+      final list = <Uri?>[];
 
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/development'));
       expect(vector.getMany(1, 2, list), equals(2));
       expect(list.length, equals(2));
-      expect(list[0].toString(), equals('https://dart.dev/docs'));
+      expect(list[0], isNull);
       expect(list[1].toString(), equals('https://flutter.dev/development'));
     });
 
@@ -1018,11 +1033,13 @@ void main() {
       expect(vector.size, equals(0));
       vector.replaceAll([
         Uri.parse('https://dart.dev/overview'),
+        null,
         Uri.parse('https://dart.dev/docs')
       ]);
-      expect(vector.size, equals(2));
+      expect(vector.size, equals(3));
       expect(vector.getAt(0), equals(Uri.parse('https://dart.dev/overview')));
-      expect(vector.getAt(1), equals(Uri.parse('https://dart.dev/docs')));
+      expect(vector.getAt(1), isNull);
+      expect(vector.getAt(2), equals(Uri.parse('https://dart.dev/docs')));
       vector.replaceAll([
         Uri.parse('https://flutter.dev/development'),
         Uri.parse('https://flutter.dev/multi-platform')
@@ -1037,12 +1054,12 @@ void main() {
     test('toList', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/development'));
       final list = vector.toList();
       expect(list.length, equals(3));
       expect(list[0], equals(Uri.parse('https://dart.dev/overview')));
-      expect(list[1], equals(Uri.parse('https://dart.dev/docs')));
+      expect(list[1], isNull);
       expect(list[2], equals(Uri.parse('https://flutter.dev/development')));
       expect(() => list..clear(), throwsUnsupportedError);
     });
@@ -1050,13 +1067,13 @@ void main() {
     test('first', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/development'));
       final iterator = vector.first();
       expect(iterator.hasCurrent, isTrue);
       expect(iterator.current, equals(Uri.parse('https://dart.dev/overview')));
       expect(iterator.moveNext(), isTrue);
-      expect(iterator.current, equals(Uri.parse('https://dart.dev/docs')));
+      expect(iterator.current, isNull);
       expect(iterator.moveNext(), isTrue);
       expect(iterator.current,
           equals(Uri.parse('https://flutter.dev/development')));
@@ -1066,10 +1083,10 @@ void main() {
     test('operator []', () {
       final vector = getVector()
         ..append(Uri.parse('https://dart.dev/overview'))
-        ..append(Uri.parse('https://dart.dev/docs'))
+        ..append(null)
         ..append(Uri.parse('https://flutter.dev/development'));
       expect(vector[0], equals(Uri.parse('https://dart.dev/overview')));
-      expect(vector[1], equals(Uri.parse('https://dart.dev/docs')));
+      expect(vector[1], isNull);
       expect(vector[2], equals(Uri.parse('https://flutter.dev/development')));
     });
 

--- a/packages/windows_foundation/test/uri_test.dart
+++ b/packages/windows_foundation/test/uri_test.dart
@@ -38,11 +38,11 @@ void main() {
     final queryParameters = queryParsed.toList();
     expect(queryParameters.length, equals(2));
     final firstQueryParam = queryParameters.first;
-    expect(firstQueryParam.name, equals('q1'));
-    expect(firstQueryParam.value, equals('v1'));
+    expect(firstQueryParam?.name, equals('q1'));
+    expect(firstQueryParam?.value, equals('v1'));
     final lastQueryParam = queryParameters.last;
-    expect(lastQueryParam.name, equals('q2'));
-    expect(lastQueryParam.value, equals('v2'));
+    expect(lastQueryParam?.name, equals('q2'));
+    expect(lastQueryParam?.value, equals('v2'));
     expect(winrtUri.fragment, equals('#fragment'));
   });
 }

--- a/packages/windows_gaming/lib/src/input/gamepad.dart
+++ b/packages/windows_gaming/lib/src/input/gamepad.dart
@@ -58,7 +58,7 @@ class Gamepad extends IInspectable
           IGamepadStatics.fromPtr, _className, IID_IGamepadStatics)
       .remove_GamepadRemoved(token);
 
-  static List<Gamepad> get gamepads => createActivationFactory(
+  static List<Gamepad?> get gamepads => createActivationFactory(
           IGamepadStatics.fromPtr, _className, IID_IGamepadStatics)
       .gamepads;
 

--- a/packages/windows_gaming/lib/src/input/igamecontroller.dart
+++ b/packages/windows_gaming/lib/src/input/igamecontroller.dart
@@ -180,7 +180,7 @@ class IGameController extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -232,7 +232,7 @@ class IGameController extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_gaming/lib/src/input/igamecontrollerbatteryinfo.dart
+++ b/packages/windows_gaming/lib/src/input/igamecontrollerbatteryinfo.dart
@@ -47,7 +47,7 @@ class IGameControllerBatteryInfo extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_gaming/lib/src/input/igamepadstatics.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics.dart
@@ -115,7 +115,7 @@ class IGamepadStatics extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  List<Gamepad> get gamepads {
+  List<Gamepad?> get gamepads {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -135,7 +135,7 @@ class IGamepadStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Gamepad>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Gamepad?>.fromPtr(retValuePtr,
         iterableIid: '{47132ba0-6b17-5cd2-a8bd-b5d3443ccb13}',
         creator: Gamepad.fromPtr);
     return vectorView.toList();

--- a/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
@@ -54,7 +54,7 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -81,5 +81,5 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
       _iGamepadStatics.remove_GamepadRemoved(token);
 
   @override
-  List<Gamepad> get gamepads => _iGamepadStatics.gamepads;
+  List<Gamepad?> get gamepads => _iGamepadStatics.gamepads;
 }

--- a/packages/windows_globalization/lib/src/collation/charactergroupings.dart
+++ b/packages/windows_globalization/lib/src/collation/charactergroupings.dart
@@ -24,8 +24,8 @@ import 'icharactergroupingsfactory.dart';
 class CharacterGroupings extends IInspectable
     implements
         ICharacterGroupings,
-        IVectorView<CharacterGrouping>,
-        IIterable<CharacterGrouping> {
+        IVectorView<CharacterGrouping?>,
+        IIterable<CharacterGrouping?> {
   CharacterGroupings() : super(activateClass(_className));
   CharacterGroupings.fromPtr(super.ptr);
 
@@ -43,35 +43,35 @@ class CharacterGroupings extends IInspectable
   @override
   String lookup(String text) => _iCharacterGroupings.lookup(text);
 
-  late final _iVectorView = IVectorView<CharacterGrouping>.fromPtr(
+  late final _iVectorView = IVectorView<CharacterGrouping?>.fromPtr(
       toInterface('{f7cf5a4a-2b7a-5bc9-a0c4-9dce07ff61c9}'),
       creator: CharacterGrouping.fromPtr,
       iterableIid: '{82e3abf0-06e3-5609-ba39-c51eb2f5fae6}');
 
   @override
-  CharacterGrouping getAt(int index) => _iVectorView.getAt(index);
+  CharacterGrouping? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(CharacterGrouping value, Pointer<Uint32> index) =>
+  bool indexOf(CharacterGrouping? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<CharacterGrouping> items) =>
+  int getMany(int startIndex, int itemsSize, List<CharacterGrouping?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<CharacterGrouping> first() => _iVectorView.first();
+  IIterator<CharacterGrouping?> first() => _iVectorView.first();
 
   @override
-  List<CharacterGrouping> toList() => _iVectorView.toList();
+  List<CharacterGrouping?> toList() => _iVectorView.toList();
 
   @override
-  CharacterGrouping operator [](int index) => _iVectorView[index];
+  CharacterGrouping? operator [](int index) => _iVectorView[index];
 
   @override
-  List<CharacterGrouping> operator +(List<CharacterGrouping> other) =>
+  List<CharacterGrouping?> operator +(List<CharacterGrouping?> other) =>
       toList() + other;
 }

--- a/packages/windows_globalization/lib/src/collation/icharactergroupings.dart
+++ b/packages/windows_globalization/lib/src/collation/icharactergroupings.dart
@@ -21,7 +21,7 @@ import 'charactergrouping.dart';
 const IID_ICharacterGroupings = '{b8d20a75-d4cf-4055-80e5-ce169c226496}';
 
 class ICharacterGroupings extends IInspectable
-    implements IVectorView<CharacterGrouping>, IIterable<CharacterGrouping> {
+    implements IVectorView<CharacterGrouping?>, IIterable<CharacterGrouping?> {
   // vtable begins at 6, is 1 entries long.
   ICharacterGroupings.fromPtr(super.ptr);
 
@@ -59,35 +59,35 @@ class ICharacterGroupings extends IInspectable
     }
   }
 
-  late final _iVectorView = IVectorView<CharacterGrouping>.fromPtr(
+  late final _iVectorView = IVectorView<CharacterGrouping?>.fromPtr(
       toInterface('{f7cf5a4a-2b7a-5bc9-a0c4-9dce07ff61c9}'),
       creator: CharacterGrouping.fromPtr,
       iterableIid: '{82e3abf0-06e3-5609-ba39-c51eb2f5fae6}');
 
   @override
-  CharacterGrouping getAt(int index) => _iVectorView.getAt(index);
+  CharacterGrouping? getAt(int index) => _iVectorView.getAt(index);
 
   @override
   int get size => _iVectorView.size;
 
   @override
-  bool indexOf(CharacterGrouping value, Pointer<Uint32> index) =>
+  bool indexOf(CharacterGrouping? value, Pointer<Uint32> index) =>
       _iVectorView.indexOf(value, index);
 
   @override
-  int getMany(int startIndex, int itemsSize, List<CharacterGrouping> items) =>
+  int getMany(int startIndex, int itemsSize, List<CharacterGrouping?> items) =>
       _iVectorView.getMany(startIndex, itemsSize, items);
 
   @override
-  IIterator<CharacterGrouping> first() => _iVectorView.first();
+  IIterator<CharacterGrouping?> first() => _iVectorView.first();
 
   @override
-  List<CharacterGrouping> toList() => _iVectorView.toList();
+  List<CharacterGrouping?> toList() => _iVectorView.toList();
 
   @override
-  CharacterGrouping operator [](int index) => _iVectorView[index];
+  CharacterGrouping? operator [](int index) => _iVectorView[index];
 
   @override
-  List<CharacterGrouping> operator +(List<CharacterGrouping> other) =>
+  List<CharacterGrouping?> operator +(List<CharacterGrouping?> other) =>
       toList() + other;
 }

--- a/packages/windows_globalization/lib/src/datetimeformatting/idatetimeformatterstatics.dart
+++ b/packages/windows_globalization/lib/src/datetimeformatting/idatetimeformatterstatics.dart
@@ -48,7 +48,7 @@ class IDateTimeFormatterStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -76,7 +76,7 @@ class IDateTimeFormatterStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -104,7 +104,7 @@ class IDateTimeFormatterStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -132,7 +132,7 @@ class IDateTimeFormatterStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_globalization/lib/src/icalendar.dart
+++ b/packages/windows_globalization/lib/src/icalendar.dart
@@ -48,7 +48,7 @@ class ICalendar extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_globalization/lib/src/ijapanesephoneticanalyzerstatics.dart
+++ b/packages/windows_globalization/lib/src/ijapanesephoneticanalyzerstatics.dart
@@ -29,7 +29,7 @@ class IJapanesePhoneticAnalyzerStatics extends IInspectable {
       IJapanesePhoneticAnalyzerStatics.fromPtr(
           interface.toInterface(IID_IJapanesePhoneticAnalyzerStatics));
 
-  List<JapanesePhoneme> getWords(String input) {
+  List<JapanesePhoneme?> getWords(String input) {
     final retValuePtr = calloc<COMObject>();
     final inputHString = input.toHString();
 
@@ -53,13 +53,13 @@ class IJapanesePhoneticAnalyzerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<JapanesePhoneme>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<JapanesePhoneme?>.fromPtr(retValuePtr,
         iterableIid: '{1aad17cb-1829-5236-8aef-0b75f8dfd7a6}',
         creator: JapanesePhoneme.fromPtr);
     return vectorView.toList();
   }
 
-  List<JapanesePhoneme> getWordsWithMonoRubyOption(
+  List<JapanesePhoneme?> getWordsWithMonoRubyOption(
       String input, bool monoRuby) {
     final retValuePtr = calloc<COMObject>();
     final inputHString = input.toHString();
@@ -84,7 +84,7 @@ class IJapanesePhoneticAnalyzerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<JapanesePhoneme>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<JapanesePhoneme?>.fromPtr(retValuePtr,
         iterableIid: '{1aad17cb-1829-5236-8aef-0b75f8dfd7a6}',
         creator: JapanesePhoneme.fromPtr);
     return vectorView.toList();

--- a/packages/windows_globalization/lib/src/japanesephoneticanalyzer.dart
+++ b/packages/windows_globalization/lib/src/japanesephoneticanalyzer.dart
@@ -26,12 +26,12 @@ class JapanesePhoneticAnalyzer extends IInspectable {
 
   static const _className = 'Windows.Globalization.JapanesePhoneticAnalyzer';
 
-  static List<JapanesePhoneme> getWords(String input) =>
+  static List<JapanesePhoneme?> getWords(String input) =>
       createActivationFactory(IJapanesePhoneticAnalyzerStatics.fromPtr,
               _className, IID_IJapanesePhoneticAnalyzerStatics)
           .getWords(input);
 
-  static List<JapanesePhoneme> getWordsWithMonoRubyOption(
+  static List<JapanesePhoneme?> getWordsWithMonoRubyOption(
           String input, bool monoRuby) =>
       createActivationFactory(IJapanesePhoneticAnalyzerStatics.fromPtr,
               _className, IID_IJapanesePhoneticAnalyzerStatics)

--- a/packages/windows_globalization/lib/src/numberformatting/inumberparser.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/inumberparser.dart
@@ -49,7 +49,7 @@ class INumberParser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -83,7 +83,7 @@ class INumberParser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -117,7 +117,7 @@ class INumberParser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_globalization/lib/src/numberformatting/inumberrounderoption.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/inumberrounderoption.dart
@@ -48,7 +48,7 @@ class INumberRounderOption extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_globalization/test/collections_test.dart
+++ b/packages/windows_globalization/test/collections_test.dart
@@ -54,6 +54,7 @@ void main() {
 
     test('getAt returns elements', () {
       final vectorView = getVectorView();
+      expect(vectorView.size, greaterThanOrEqualTo(1));
       final element = vectorView.getAt(0);
       // Should be something like en-US
       expect(element[2], equals('-'));

--- a/packages/windows_graphics/lib/src/imaging/bitmapdecoder.dart
+++ b/packages/windows_graphics/lib/src/imaging/bitmapdecoder.dart
@@ -69,7 +69,7 @@ class BitmapDecoder extends IInspectable
           IBitmapDecoderStatics.fromPtr, _className, IID_IBitmapDecoderStatics)
       .icoDecoderId;
 
-  static List<BitmapCodecInformation> getDecoderInformationEnumerator() =>
+  static List<BitmapCodecInformation?> getDecoderInformationEnumerator() =>
       createActivationFactory(IBitmapDecoderStatics.fromPtr, _className,
               IID_IBitmapDecoderStatics)
           .getDecoderInformationEnumerator();

--- a/packages/windows_graphics/lib/src/imaging/ibitmapdecoder.dart
+++ b/packages/windows_graphics/lib/src/imaging/ibitmapdecoder.dart
@@ -50,7 +50,7 @@ class IBitmapDecoder extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -78,7 +78,7 @@ class IBitmapDecoder extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_graphics/lib/src/imaging/ibitmapdecoderstatics.dart
+++ b/packages/windows_graphics/lib/src/imaging/ibitmapdecoderstatics.dart
@@ -198,7 +198,7 @@ class IBitmapDecoderStatics extends IInspectable {
     }
   }
 
-  List<BitmapCodecInformation> getDecoderInformationEnumerator() {
+  List<BitmapCodecInformation?> getDecoderInformationEnumerator() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -218,7 +218,7 @@ class IBitmapDecoderStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<BitmapCodecInformation>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<BitmapCodecInformation?>.fromPtr(retValuePtr,
         iterableIid: '{2b6bdb90-a4eb-5142-b582-3ccb1edc5789}',
         creator: BitmapCodecInformation.fromPtr);
     return vectorView.toList();

--- a/packages/windows_graphics/lib/src/imaging/ibitmapframe.dart
+++ b/packages/windows_graphics/lib/src/imaging/ibitmapframe.dart
@@ -79,7 +79,7 @@ class IBitmapFrame extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_graphics/lib/src/imaging/ibitmaptypedvalue.dart
+++ b/packages/windows_graphics/lib/src/imaging/ibitmaptypedvalue.dart
@@ -45,7 +45,7 @@ class IBitmapTypedValue extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_graphics/lib/src/imaging/isoftwarebitmap.dart
+++ b/packages/windows_graphics/lib/src/imaging/isoftwarebitmap.dart
@@ -253,7 +253,7 @@ class ISoftwareBitmap extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -335,7 +335,7 @@ class ISoftwareBitmap extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_graphics/lib/src/imaging/isoftwarebitmapstatics.dart
+++ b/packages/windows_graphics/lib/src/imaging/isoftwarebitmapstatics.dart
@@ -57,7 +57,7 @@ class ISoftwareBitmapStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -91,7 +91,7 @@ class ISoftwareBitmapStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -126,7 +126,7 @@ class ISoftwareBitmapStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -167,7 +167,7 @@ class ISoftwareBitmapStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -210,7 +210,7 @@ class ISoftwareBitmapStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_graphics/test/collections_test.dart
+++ b/packages/windows_graphics/test/collections_test.dart
@@ -40,6 +40,7 @@ void main() {
       final vector = getVector()
         ..append(5)
         ..append(259);
+      expect(vector.size, equals(2));
       expect(vector.getAt(0), equals(5));
       expect(vector.getAt(1), equals(259));
     });

--- a/packages/windows_media/lib/src/imediaframe.dart
+++ b/packages/windows_media/lib/src/imediaframe.dart
@@ -110,7 +110,7 @@ class IMediaFrame extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -156,7 +156,7 @@ class IMediaFrame extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -202,7 +202,7 @@ class IMediaFrame extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_media/lib/src/ivideoframe.dart
+++ b/packages/windows_media/lib/src/ivideoframe.dart
@@ -49,7 +49,7 @@ class IVideoFrame extends IInspectable implements IMediaFrame, IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -105,7 +105,7 @@ class IVideoFrame extends IInspectable implements IMediaFrame, IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_media/lib/src/ivideoframestatics.dart
+++ b/packages/windows_media/lib/src/ivideoframestatics.dart
@@ -54,7 +54,7 @@ class IVideoFrameStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -98,7 +98,7 @@ class IVideoFrameStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -131,7 +131,7 @@ class IVideoFrameStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -163,7 +163,7 @@ class IVideoFrameStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_media/lib/src/ocr/iocrengine.dart
+++ b/packages/windows_media/lib/src/ocr/iocrengine.dart
@@ -79,7 +79,7 @@ class IOcrEngine extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_media/lib/src/ocr/iocrenginestatics.dart
+++ b/packages/windows_media/lib/src/ocr/iocrenginestatics.dart
@@ -52,7 +52,7 @@ class IOcrEngineStatics extends IInspectable {
     }
   }
 
-  List<Language> get availableRecognizerLanguages {
+  List<Language?> get availableRecognizerLanguages {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -72,7 +72,7 @@ class IOcrEngineStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Language>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Language?>.fromPtr(retValuePtr,
         iterableIid: '{48409a10-61b6-5db1-a69d-8abc46ac608a}',
         creator: Language.fromPtr);
     return vectorView.toList();
@@ -131,7 +131,7 @@ class IOcrEngineStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -159,7 +159,7 @@ class IOcrEngineStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_media/lib/src/ocr/iocrline.dart
+++ b/packages/windows_media/lib/src/ocr/iocrline.dart
@@ -27,7 +27,7 @@ class IOcrLine extends IInspectable {
   factory IOcrLine.from(IInspectable interface) =>
       IOcrLine.fromPtr(interface.toInterface(IID_IOcrLine));
 
-  List<OcrWord> get words {
+  List<OcrWord?> get words {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -47,7 +47,7 @@ class IOcrLine extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<OcrWord>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<OcrWord?>.fromPtr(retValuePtr,
         iterableIid: '{a0ce663a-46d0-55e5-928e-251eb67a1e99}',
         creator: OcrWord.fromPtr);
     return vectorView.toList();

--- a/packages/windows_media/lib/src/ocr/iocrresult.dart
+++ b/packages/windows_media/lib/src/ocr/iocrresult.dart
@@ -27,7 +27,7 @@ class IOcrResult extends IInspectable {
   factory IOcrResult.from(IInspectable interface) =>
       IOcrResult.fromPtr(interface.toInterface(IID_IOcrResult));
 
-  List<OcrLine> get lines {
+  List<OcrLine?> get lines {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -47,7 +47,7 @@ class IOcrResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<OcrLine>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<OcrLine?>.fromPtr(retValuePtr,
         iterableIid: '{6afa94a2-60d7-5dbe-942d-81aa3929c85e}',
         creator: OcrLine.fromPtr);
     return vectorView.toList();
@@ -73,7 +73,7 @@ class IOcrResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_media/lib/src/ocr/ocrengine.dart
+++ b/packages/windows_media/lib/src/ocr/ocrengine.dart
@@ -31,7 +31,7 @@ class OcrEngine extends IInspectable implements IOcrEngine {
           IOcrEngineStatics.fromPtr, _className, IID_IOcrEngineStatics)
       .maxImageDimension;
 
-  static List<Language> get availableRecognizerLanguages =>
+  static List<Language?> get availableRecognizerLanguages =>
       createActivationFactory(
               IOcrEngineStatics.fromPtr, _className, IID_IOcrEngineStatics)
           .availableRecognizerLanguages;

--- a/packages/windows_media/lib/src/ocr/ocrline.dart
+++ b/packages/windows_media/lib/src/ocr/ocrline.dart
@@ -26,7 +26,7 @@ class OcrLine extends IInspectable implements IOcrLine {
   late final _iOcrLine = IOcrLine.from(this);
 
   @override
-  List<OcrWord> get words => _iOcrLine.words;
+  List<OcrWord?> get words => _iOcrLine.words;
 
   @override
   String get text => _iOcrLine.text;

--- a/packages/windows_media/lib/src/ocr/ocrresult.dart
+++ b/packages/windows_media/lib/src/ocr/ocrresult.dart
@@ -25,7 +25,7 @@ class OcrResult extends IInspectable implements IOcrResult {
   late final _iOcrResult = IOcrResult.from(this);
 
   @override
-  List<OcrLine> get lines => _iOcrResult.lines;
+  List<OcrLine?> get lines => _iOcrResult.lines;
 
   @override
   double? get textAngle => _iOcrResult.textAngle;

--- a/packages/windows_networking/lib/src/connectivity/connectionprofile.dart
+++ b/packages/windows_networking/lib/src/connectivity/connectionprofile.dart
@@ -123,7 +123,7 @@ class ConnectionProfile extends IInspectable
       _iConnectionProfile2.getDomainConnectivityLevel();
 
   @override
-  Future<List<NetworkUsage>> getNetworkUsageAsync(
+  Future<List<NetworkUsage?>> getNetworkUsageAsync(
           DateTime startTime,
           DateTime endTime,
           DataUsageGranularity granularity,
@@ -132,7 +132,7 @@ class ConnectionProfile extends IInspectable
           startTime, endTime, granularity, states);
 
   @override
-  Future<List<ConnectivityInterval>> getConnectivityIntervalsAsync(
+  Future<List<ConnectivityInterval?>> getConnectivityIntervalsAsync(
           DateTime startTime, DateTime endTime, NetworkUsageStates states) =>
       _iConnectionProfile2.getConnectivityIntervalsAsync(
           startTime, endTime, states);
@@ -140,7 +140,7 @@ class ConnectionProfile extends IInspectable
   late final _iConnectionProfile3 = IConnectionProfile3.from(this);
 
   @override
-  Future<List<AttributedNetworkUsage>> getAttributedNetworkUsageAsync(
+  Future<List<AttributedNetworkUsage?>> getAttributedNetworkUsageAsync(
           DateTime startTime, DateTime endTime, NetworkUsageStates states) =>
       _iConnectionProfile3.getAttributedNetworkUsageAsync(
           startTime, endTime, states);
@@ -148,7 +148,7 @@ class ConnectionProfile extends IInspectable
   late final _iConnectionProfile4 = IConnectionProfile4.from(this);
 
   @override
-  Future<List<ProviderNetworkUsage>> getProviderNetworkUsageAsync(
+  Future<List<ProviderNetworkUsage?>> getProviderNetworkUsageAsync(
           DateTime startTime, DateTime endTime, NetworkUsageStates states) =>
       _iConnectionProfile4.getProviderNetworkUsageAsync(
           startTime, endTime, states);

--- a/packages/windows_networking/lib/src/connectivity/iattributednetworkusage.dart
+++ b/packages/windows_networking/lib/src/connectivity/iattributednetworkusage.dart
@@ -145,7 +145,7 @@ class IAttributedNetworkUsage extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile.dart
@@ -127,7 +127,7 @@ class IConnectionProfile extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -155,7 +155,7 @@ class IConnectionProfile extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -183,7 +183,7 @@ class IConnectionProfile extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -214,7 +214,7 @@ class IConnectionProfile extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -254,7 +254,7 @@ class IConnectionProfile extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -282,7 +282,7 @@ class IConnectionProfile extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile2.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile2.dart
@@ -102,7 +102,7 @@ class IConnectionProfile2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -130,7 +130,7 @@ class IConnectionProfile2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -158,7 +158,7 @@ class IConnectionProfile2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -188,7 +188,7 @@ class IConnectionProfile2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -222,7 +222,7 @@ class IConnectionProfile2 extends IInspectable {
     }
   }
 
-  Future<List<NetworkUsage>> getNetworkUsageAsync(
+  Future<List<NetworkUsage?>> getNetworkUsageAsync(
       DateTime startTime,
       DateTime endTime,
       DataUsageGranularity granularity,
@@ -265,7 +265,7 @@ class IConnectionProfile2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<NetworkUsage>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<NetworkUsage?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: NetworkUsage.fromPtr,
@@ -273,7 +273,7 @@ class IConnectionProfile2 extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<ConnectivityInterval>> getConnectivityIntervalsAsync(
+  Future<List<ConnectivityInterval?>> getConnectivityIntervalsAsync(
       DateTime startTime, DateTime endTime, NetworkUsageStates states) {
     final retValuePtr = calloc<COMObject>();
     final statesNativeStructPtr = states.toNative();
@@ -311,7 +311,7 @@ class IConnectionProfile2 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVectorView<ConnectivityInterval>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVectorView<ConnectivityInterval?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVectorView.fromPtr(ptr,
                 creator: ConnectivityInterval.fromPtr,
                 iterableIid: '{58051a8b-b259-5414-9b9a-caa0789e833e}'));

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile3.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile3.dart
@@ -29,7 +29,7 @@ class IConnectionProfile3 extends IInspectable {
       IConnectionProfile3.fromPtr(
           interface.toInterface(IID_IConnectionProfile3));
 
-  Future<List<AttributedNetworkUsage>> getAttributedNetworkUsageAsync(
+  Future<List<AttributedNetworkUsage?>> getAttributedNetworkUsageAsync(
       DateTime startTime, DateTime endTime, NetworkUsageStates states) {
     final retValuePtr = calloc<COMObject>();
     final statesNativeStructPtr = states.toNative();
@@ -67,7 +67,7 @@ class IConnectionProfile3 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVectorView<AttributedNetworkUsage>>.fromPtr(
+        IAsyncOperation<IVectorView<AttributedNetworkUsage?>>.fromPtr(
             retValuePtr,
             creator: (ptr) => IVectorView.fromPtr(ptr,
                 creator: AttributedNetworkUsage.fromPtr,

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofile4.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofile4.dart
@@ -29,7 +29,7 @@ class IConnectionProfile4 extends IInspectable {
       IConnectionProfile4.fromPtr(
           interface.toInterface(IID_IConnectionProfile4));
 
-  Future<List<ProviderNetworkUsage>> getProviderNetworkUsageAsync(
+  Future<List<ProviderNetworkUsage?>> getProviderNetworkUsageAsync(
       DateTime startTime, DateTime endTime, NetworkUsageStates states) {
     final retValuePtr = calloc<COMObject>();
     final statesNativeStructPtr = states.toNative();
@@ -67,7 +67,7 @@ class IConnectionProfile4 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVectorView<ProviderNetworkUsage>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVectorView<ProviderNetworkUsage?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVectorView.fromPtr(ptr,
                 creator: ProviderNetworkUsage.fromPtr,
                 iterableIid: '{f79bc7ba-01df-51ec-bfaf-fd883f698e07}'));

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofilefilter.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofilefilter.dart
@@ -216,7 +216,7 @@ class IConnectionProfileFilter extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofilefilter2.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofilefilter2.dart
@@ -63,7 +63,7 @@ class IConnectionProfileFilter2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -109,7 +109,7 @@ class IConnectionProfileFilter2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -155,7 +155,7 @@ class IConnectionProfileFilter2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -185,7 +185,7 @@ class IConnectionProfileFilter2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/iconnectionprofilefilter3.dart
+++ b/packages/windows_networking/lib/src/connectivity/iconnectionprofilefilter3.dart
@@ -62,7 +62,7 @@ class IConnectionProfileFilter3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/idataplanstatus.dart
+++ b/packages/windows_networking/lib/src/connectivity/idataplanstatus.dart
@@ -47,7 +47,7 @@ class IDataPlanStatus extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -75,7 +75,7 @@ class IDataPlanStatus extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -105,7 +105,7 @@ class IDataPlanStatus extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -135,7 +135,7 @@ class IDataPlanStatus extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -165,7 +165,7 @@ class IDataPlanStatus extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -195,7 +195,7 @@ class IDataPlanStatus extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/iipinformation.dart
+++ b/packages/windows_networking/lib/src/connectivity/iipinformation.dart
@@ -47,7 +47,7 @@ class IIPInformation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -75,7 +75,7 @@ class IIPInformation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/ilanidentifier.dart
+++ b/packages/windows_networking/lib/src/connectivity/ilanidentifier.dart
@@ -47,7 +47,7 @@ class ILanIdentifier extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -75,7 +75,7 @@ class ILanIdentifier extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/inetworkadapter.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkadapter.dart
@@ -120,7 +120,7 @@ class INetworkAdapter extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics.dart
@@ -33,7 +33,7 @@ class INetworkInformationStatics extends IInspectable {
       INetworkInformationStatics.fromPtr(
           interface.toInterface(IID_INetworkInformationStatics));
 
-  List<ConnectionProfile> getConnectionProfiles() {
+  List<ConnectionProfile?> getConnectionProfiles() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -53,7 +53,7 @@ class INetworkInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<ConnectionProfile>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<ConnectionProfile?>.fromPtr(retValuePtr,
         iterableIid: '{34dabef9-87d0-5b1c-a7ac-9d290adeb0c8}',
         creator: ConnectionProfile.fromPtr);
     return vectorView.toList();
@@ -79,7 +79,7 @@ class INetworkInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -87,7 +87,7 @@ class INetworkInformationStatics extends IInspectable {
     return ConnectionProfile.fromPtr(retValuePtr);
   }
 
-  List<LanIdentifier> getLanIdentifiers() {
+  List<LanIdentifier?> getLanIdentifiers() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -107,13 +107,13 @@ class INetworkInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<LanIdentifier>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<LanIdentifier?>.fromPtr(retValuePtr,
         iterableIid: '{accef3cd-5d92-5c01-8ac4-79fe74cd733e}',
         creator: LanIdentifier.fromPtr);
     return vectorView.toList();
   }
 
-  List<HostName> getHostNames() {
+  List<HostName?> getHostNames() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -133,7 +133,7 @@ class INetworkInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<HostName>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<HostName?>.fromPtr(retValuePtr,
         iterableIid: '{9e5f3ed0-cf1c-5d38-832c-acea6164bf5c}',
         creator: HostName.fromPtr);
     return vectorView.toList();
@@ -170,8 +170,8 @@ class INetworkInformationStatics extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  List<EndpointPair> getSortedEndpointPairs(
-      IIterable<EndpointPair>? destinationList,
+  List<EndpointPair?> getSortedEndpointPairs(
+      IIterable<EndpointPair?>? destinationList,
       HostNameSortOptions sortOptions) {
     final retValuePtr = calloc<COMObject>();
     final destinationListPtr = destinationList == null
@@ -206,7 +206,7 @@ class INetworkInformationStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<EndpointPair>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<EndpointPair?>.fromPtr(retValuePtr,
         iterableIid: '{d7ec83c4-a17b-51bf-8997-aa33b9102dc9}',
         creator: EndpointPair.fromPtr);
     return vectorView.toList();

--- a/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics2.dart
+++ b/packages/windows_networking/lib/src/connectivity/inetworkinformationstatics2.dart
@@ -30,7 +30,7 @@ class INetworkInformationStatics2 extends IInspectable {
       INetworkInformationStatics2.fromPtr(
           interface.toInterface(IID_INetworkInformationStatics2));
 
-  Future<List<ConnectionProfile>> findConnectionProfilesAsync(
+  Future<List<ConnectionProfile?>> findConnectionProfilesAsync(
       ConnectionProfileFilter? pProfileFilter) {
     final retValuePtr = calloc<COMObject>();
     final pProfileFilterPtr =
@@ -57,7 +57,8 @@ class INetworkInformationStatics2 extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVectorView<ConnectionProfile>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVectorView<ConnectionProfile?>>.fromPtr(
+            retValuePtr,
             creator: (ptr) => IVectorView.fromPtr(ptr,
                 creator: ConnectionProfile.fromPtr,
                 iterableIid: '{34dabef9-87d0-5b1c-a7ac-9d290adeb0c8}'));

--- a/packages/windows_networking/lib/src/connectivity/iproxyconfiguration.dart
+++ b/packages/windows_networking/lib/src/connectivity/iproxyconfiguration.dart
@@ -26,7 +26,7 @@ class IProxyConfiguration extends IInspectable {
       IProxyConfiguration.fromPtr(
           interface.toInterface(IID_IProxyConfiguration));
 
-  List<Uri> get proxyUris {
+  List<Uri?> get proxyUris {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -46,7 +46,7 @@ class IProxyConfiguration extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<Uri>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<Uri?>.fromPtr(retValuePtr,
         iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}');
     return vectorView.toList();
   }

--- a/packages/windows_networking/lib/src/connectivity/networkinformation.dart
+++ b/packages/windows_networking/lib/src/connectivity/networkinformation.dart
@@ -32,7 +32,7 @@ class NetworkInformation extends IInspectable {
   static const _className =
       'Windows.Networking.Connectivity.NetworkInformation';
 
-  static List<ConnectionProfile> getConnectionProfiles() =>
+  static List<ConnectionProfile?> getConnectionProfiles() =>
       createActivationFactory(INetworkInformationStatics.fromPtr, _className,
               IID_INetworkInformationStatics)
           .getConnectionProfiles();
@@ -42,13 +42,13 @@ class NetworkInformation extends IInspectable {
               IID_INetworkInformationStatics)
           .getInternetConnectionProfile();
 
-  static List<LanIdentifier> getLanIdentifiers() => createActivationFactory(
+  static List<LanIdentifier?> getLanIdentifiers() => createActivationFactory(
           INetworkInformationStatics.fromPtr,
           _className,
           IID_INetworkInformationStatics)
       .getLanIdentifiers();
 
-  static List<HostName> getHostNames() => createActivationFactory(
+  static List<HostName?> getHostNames() => createActivationFactory(
           INetworkInformationStatics.fromPtr,
           _className,
           IID_INetworkInformationStatics)
@@ -59,8 +59,8 @@ class NetworkInformation extends IInspectable {
               IID_INetworkInformationStatics)
           .getProxyConfigurationAsync(uri);
 
-  static List<EndpointPair> getSortedEndpointPairs(
-          IIterable<EndpointPair>? destinationList,
+  static List<EndpointPair?> getSortedEndpointPairs(
+          IIterable<EndpointPair?>? destinationList,
           HostNameSortOptions sortOptions) =>
       createActivationFactory(INetworkInformationStatics.fromPtr, _className,
               IID_INetworkInformationStatics)
@@ -77,7 +77,7 @@ class NetworkInformation extends IInspectable {
               IID_INetworkInformationStatics)
           .remove_NetworkStatusChanged(eventCookie);
 
-  static Future<List<ConnectionProfile>> findConnectionProfilesAsync(
+  static Future<List<ConnectionProfile?>> findConnectionProfilesAsync(
           ConnectionProfileFilter? pProfileFilter) =>
       createActivationFactory(INetworkInformationStatics2.fromPtr, _className,
               IID_INetworkInformationStatics2)

--- a/packages/windows_networking/lib/src/connectivity/proxyconfiguration.dart
+++ b/packages/windows_networking/lib/src/connectivity/proxyconfiguration.dart
@@ -24,7 +24,7 @@ class ProxyConfiguration extends IInspectable implements IProxyConfiguration {
   late final _iProxyConfiguration = IProxyConfiguration.from(this);
 
   @override
-  List<Uri> get proxyUris => _iProxyConfiguration.proxyUris;
+  List<Uri?> get proxyUris => _iProxyConfiguration.proxyUris;
 
   @override
   bool get canConnectDirectly => _iProxyConfiguration.canConnectDirectly;

--- a/packages/windows_networking/lib/src/iendpointpair.dart
+++ b/packages/windows_networking/lib/src/iendpointpair.dart
@@ -47,7 +47,7 @@ class IEndpointPair extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -138,7 +138,7 @@ class IEndpointPair extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/ihostname.dart
+++ b/packages/windows_networking/lib/src/ihostname.dart
@@ -49,7 +49,7 @@ class IHostName extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringclient.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringclient.dart
@@ -54,7 +54,7 @@ class INetworkOperatorTetheringClient extends IInspectable {
     }
   }
 
-  List<HostName> get hostNames {
+  List<HostName?> get hostNames {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -74,7 +74,7 @@ class INetworkOperatorTetheringClient extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<HostName>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<HostName?>.fromPtr(retValuePtr,
         iterableIid: '{9e5f3ed0-cf1c-5d38-832c-acea6164bf5c}',
         creator: HostName.fromPtr);
     return vectorView.toList();

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringclientmanager.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringclientmanager.dart
@@ -29,7 +29,7 @@ class INetworkOperatorTetheringClientManager extends IInspectable {
       INetworkOperatorTetheringClientManager.fromPtr(
           interface.toInterface(IID_INetworkOperatorTetheringClientManager));
 
-  List<NetworkOperatorTetheringClient> getTetheringClients() {
+  List<NetworkOperatorTetheringClient?> getTetheringClients() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -49,7 +49,7 @@ class INetworkOperatorTetheringClientManager extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<NetworkOperatorTetheringClient>.fromPtr(
+    final vectorView = IVectorView<NetworkOperatorTetheringClient?>.fromPtr(
         retValuePtr,
         iterableIid: '{4762ecb3-af48-5b63-89b7-78a42056549f}',
         creator: NetworkOperatorTetheringClient.fromPtr);

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanager.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanager.dart
@@ -124,7 +124,7 @@ class INetworkOperatorTetheringManager extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanagerstatics.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanagerstatics.dart
@@ -89,7 +89,7 @@ class INetworkOperatorTetheringManagerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanagerstatics2.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanagerstatics2.dart
@@ -87,7 +87,7 @@ class INetworkOperatorTetheringManagerStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanagerstatics3.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringmanagerstatics3.dart
@@ -59,7 +59,7 @@ class INetworkOperatorTetheringManagerStatics3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_networking/lib/src/networkoperators/networkoperatortetheringclient.dart
+++ b/packages/windows_networking/lib/src/networkoperators/networkoperatortetheringclient.dart
@@ -30,5 +30,5 @@ class NetworkOperatorTetheringClient extends IInspectable
   String get macAddress => _iNetworkOperatorTetheringClient.macAddress;
 
   @override
-  List<HostName> get hostNames => _iNetworkOperatorTetheringClient.hostNames;
+  List<HostName?> get hostNames => _iNetworkOperatorTetheringClient.hostNames;
 }

--- a/packages/windows_networking/lib/src/networkoperators/networkoperatortetheringmanager.dart
+++ b/packages/windows_networking/lib/src/networkoperators/networkoperatortetheringmanager.dart
@@ -136,6 +136,6 @@ class NetworkOperatorTetheringManager extends IInspectable
       INetworkOperatorTetheringClientManager.from(this);
 
   @override
-  List<NetworkOperatorTetheringClient> getTetheringClients() =>
+  List<NetworkOperatorTetheringClient?> getTetheringClients() =>
       _iNetworkOperatorTetheringClientManager.getTetheringClients();
 }

--- a/packages/windows_networking/test/collections_test.dart
+++ b/packages/windows_networking/test/collections_test.dart
@@ -19,8 +19,8 @@ void main() {
     return;
   }
 
-  group('IVectorView<HostName>', () {
-    IVectorView<HostName> getHostNames(Pointer<COMObject> ptr) {
+  group('IVectorView<HostName?>', () {
+    IVectorView<HostName?> getHostNames(Pointer<COMObject> ptr) {
       final retValuePtr = calloc<COMObject>();
 
       final hr = ptr.ref.vtable
@@ -36,13 +36,16 @@ void main() {
                       VTablePointer lpVtbl, Pointer<COMObject> retValuePtr)>()(
           ptr.ref.lpVtbl, retValuePtr);
 
-      if (FAILED(hr)) throw WindowsException(hr);
+      if (FAILED(hr)) {
+        free(retValuePtr);
+        throw WindowsException(hr);
+      }
 
       return IVectorView.fromPtr(retValuePtr,
           creator: HostName.fromPtr, iterableIid: IID_IIterable_HostName);
     }
 
-    IVectorView<HostName> getVectorView() {
+    IVectorView<HostName?> getVectorView() {
       final object = createActivationFactory(
           IInspectable.new,
           'Windows.Networking.Connectivity.NetworkInformation',
@@ -58,8 +61,9 @@ void main() {
 
     test('getAt returns elements', () {
       final vectorView = getVectorView();
+      expect(vectorView.size, greaterThanOrEqualTo(1));
       final hostName = vectorView.getAt(0);
-      expect(hostName.displayName, isNotEmpty);
+      expect(hostName?.displayName, isNotEmpty);
     });
 
     test('indexOf finds element', () {
@@ -75,7 +79,7 @@ void main() {
     });
 
     test('getMany returns elements starting from index 0', () {
-      final list = <HostName>[];
+      final list = <HostName?>[];
       final vectorView = getVectorView();
       expect(vectorView.getMany(0, vectorView.size, list),
           greaterThanOrEqualTo(1));
@@ -85,7 +89,7 @@ void main() {
     test(
         'getMany returns all elements if valueSize is greater than the number '
         'of elements', () {
-      final list = <HostName>[];
+      final list = <HostName?>[];
       final vectorView = getVectorView();
       expect(vectorView.getMany(0, vectorView.size + 1, list),
           greaterThanOrEqualTo(1));
@@ -106,7 +110,7 @@ void main() {
 
       for (var i = 0; i < list.length; i++) {
         expect(iterator.hasCurrent, isTrue);
-        expect(iterator.current.rawName, equals(list[i].rawName));
+        expect(iterator.current?.rawName, equals(list[i]?.rawName));
         // moveNext() should return true except for the last iteration
         expect(iterator.moveNext(), i < list.length - 1);
       }
@@ -114,7 +118,7 @@ void main() {
 
     test('operator []', () {
       final vector = getVectorView();
-      expect(vector[0].displayName, isNotEmpty);
+      expect(vector[0]?.displayName, isNotEmpty);
     });
 
     test('operator +', () {
@@ -122,8 +126,8 @@ void main() {
       final list = [HostName.createHostName('test')];
       final newList = vector + list;
       expect(newList.length, equals(vector.size + 1));
-      expect(newList.first.displayName, isNotEmpty);
-      expect(newList.last.displayName, equals('test'));
+      expect(newList.first?.displayName, isNotEmpty);
+      expect(newList.last?.displayName, equals('test'));
     });
   });
 }

--- a/packages/windows_security/lib/src/authentication/web/core/findallaccountsresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/findallaccountsresult.dart
@@ -28,7 +28,7 @@ class FindAllAccountsResult extends IInspectable
   late final _iFindAllAccountsResult = IFindAllAccountsResult.from(this);
 
   @override
-  List<WebAccount> get accounts => _iFindAllAccountsResult.accounts;
+  List<WebAccount?> get accounts => _iFindAllAccountsResult.accounts;
 
   @override
   FindAllWebAccountsStatus get status => _iFindAllAccountsResult.status;

--- a/packages/windows_security/lib/src/authentication/web/core/ifindallaccountsresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/ifindallaccountsresult.dart
@@ -30,7 +30,7 @@ class IFindAllAccountsResult extends IInspectable {
       IFindAllAccountsResult.fromPtr(
           interface.toInterface(IID_IFindAllAccountsResult));
 
-  List<WebAccount> get accounts {
+  List<WebAccount?> get accounts {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -50,7 +50,7 @@ class IFindAllAccountsResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<WebAccount>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<WebAccount?>.fromPtr(retValuePtr,
         iterableIid: '{cb15d439-a910-542a-89ed-7cfe67848a83}',
         creator: WebAccount.fromPtr);
     return vectorView.toList();
@@ -100,7 +100,7 @@ class IFindAllAccountsResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/authentication/web/core/iwebauthenticationcoremanagerstatics3.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebauthenticationcoremanagerstatics3.dart
@@ -36,7 +36,7 @@ class IWebAuthenticationCoreManagerStatics3 extends IInspectable
           interface.toInterface(IID_IWebAuthenticationCoreManagerStatics3));
 
   WebAccountMonitor? createWebAccountMonitor(
-      IIterable<WebAccount>? webAccounts) {
+      IIterable<WebAccount?>? webAccounts) {
     final retValuePtr = calloc<COMObject>();
     final webAccountsPtr = webAccounts == null
         ? nullptr
@@ -66,7 +66,7 @@ class IWebAuthenticationCoreManagerStatics3 extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequest.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequest.dart
@@ -48,7 +48,7 @@ class IWebTokenRequest extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequestresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequestresult.dart
@@ -30,7 +30,7 @@ class IWebTokenRequestResult extends IInspectable {
       IWebTokenRequestResult.fromPtr(
           interface.toInterface(IID_IWebTokenRequestResult));
 
-  List<WebTokenResponse> get responseData {
+  List<WebTokenResponse?> get responseData {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -50,7 +50,7 @@ class IWebTokenRequestResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<WebTokenResponse>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<WebTokenResponse?>.fromPtr(retValuePtr,
         iterableIid: '{7e5bb7ec-bbd7-5575-9a61-f5815fa22a0e}',
         creator: WebTokenResponse.fromPtr);
     return vectorView.toList();
@@ -100,7 +100,7 @@ class IWebTokenRequestResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenresponse.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenresponse.dart
@@ -73,7 +73,7 @@ class IWebTokenResponse extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -101,7 +101,7 @@ class IWebTokenResponse extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/authentication/web/core/webauthenticationcoremanager.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webauthenticationcoremanager.dart
@@ -86,7 +86,7 @@ class WebAuthenticationCoreManager extends IInspectable {
                   webAccountProviderId, authority, user);
 
   static WebAccountMonitor? createWebAccountMonitor(
-          IIterable<WebAccount>? webAccounts) =>
+          IIterable<WebAccount?>? webAccounts) =>
       createActivationFactory(IWebAuthenticationCoreManagerStatics3.fromPtr,
               _className, IID_IWebAuthenticationCoreManagerStatics3)
           .createWebAccountMonitor(webAccounts);

--- a/packages/windows_security/lib/src/authentication/web/core/webtokenrequestresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webtokenrequestresult.dart
@@ -28,7 +28,7 @@ class WebTokenRequestResult extends IInspectable
   late final _iWebTokenRequestResult = IWebTokenRequestResult.from(this);
 
   @override
-  List<WebTokenResponse> get responseData =>
+  List<WebTokenResponse?> get responseData =>
       _iWebTokenRequestResult.responseData;
 
   @override

--- a/packages/windows_security/lib/src/credentials/iwebaccount.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccount.dart
@@ -48,7 +48,7 @@ class IWebAccount extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/credentials/iwebaccountprovider.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountprovider.dart
@@ -98,7 +98,7 @@ class IWebAccountProvider extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_security/lib/src/credentials/iwebaccountprovider3.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountprovider3.dart
@@ -51,7 +51,7 @@ class IWebAccountProvider3 extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/example/storage.dart
+++ b/packages/windows_storage/example/storage.dart
@@ -5,15 +5,21 @@
 import 'package:win32/win32.dart';
 import 'package:windows_storage/windows_storage.dart';
 
+void printStorageFile(StorageFile? file) {
+  if (file == null) return;
+  final StorageFile(:name, :path, :dateCreated, :contentType) = file;
+  print('Name: $name, path: $path, date created: $dateCreated, '
+      'content type: $contentType');
+}
+
 void main() async {
   final folder = KnownFolders.documentsLibrary;
   if (folder == null) return;
 
   // Retrieve all files in the Documents library
   final files = await folder.getFilesAsyncOverloadDefaultOptionsStartAndCount();
-  for (final StorageFile(:name, :path, :dateCreated, :contentType) in files) {
-    print('Name: $name, path: $path, date created: $dateCreated, '
-        'content type: $contentType');
+  for (final file in files) {
+    printStorageFile(file);
   }
 
   try {

--- a/packages/windows_storage/lib/src/fileproperties/iimageproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/iimageproperties.dart
@@ -246,7 +246,7 @@ class IImageProperties extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -276,7 +276,7 @@ class IImageProperties extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/fileproperties/ivideoproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/ivideoproperties.dart
@@ -185,7 +185,7 @@ class IVideoProperties extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -215,7 +215,7 @@ class IVideoProperties extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iapplicationdata.dart
+++ b/packages/windows_storage/lib/src/iapplicationdata.dart
@@ -148,7 +148,7 @@ class IApplicationData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -176,7 +176,7 @@ class IApplicationData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -204,7 +204,7 @@ class IApplicationData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -232,7 +232,7 @@ class IApplicationData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -260,7 +260,7 @@ class IApplicationData extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iapplicationdata2.dart
+++ b/packages/windows_storage/lib/src/iapplicationdata2.dart
@@ -47,7 +47,7 @@ class IApplicationData2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iapplicationdata3.dart
+++ b/packages/windows_storage/lib/src/iapplicationdata3.dart
@@ -54,7 +54,7 @@ class IApplicationData3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -112,7 +112,7 @@ class IApplicationData3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iapplicationdatacontainer.dart
+++ b/packages/windows_storage/lib/src/iapplicationdatacontainer.dart
@@ -158,7 +158,7 @@ class IApplicationDataContainer extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iapplicationdatastatics.dart
+++ b/packages/windows_storage/lib/src/iapplicationdatastatics.dart
@@ -48,7 +48,7 @@ class IApplicationDataStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iknownfolderscamerarollstatics.dart
+++ b/packages/windows_storage/lib/src/iknownfolderscamerarollstatics.dart
@@ -49,7 +49,7 @@ class IKnownFoldersCameraRollStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iknownfoldersplaylistsstatics.dart
+++ b/packages/windows_storage/lib/src/iknownfoldersplaylistsstatics.dart
@@ -49,7 +49,7 @@ class IKnownFoldersPlaylistsStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iknownfolderssavedpicturesstatics.dart
+++ b/packages/windows_storage/lib/src/iknownfolderssavedpicturesstatics.dart
@@ -49,7 +49,7 @@ class IKnownFoldersSavedPicturesStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iknownfoldersstatics.dart
+++ b/packages/windows_storage/lib/src/iknownfoldersstatics.dart
@@ -48,7 +48,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -76,7 +76,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -104,7 +104,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -132,7 +132,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -160,7 +160,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -188,7 +188,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -216,7 +216,7 @@ class IKnownFoldersStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iknownfoldersstatics2.dart
+++ b/packages/windows_storage/lib/src/iknownfoldersstatics2.dart
@@ -48,7 +48,7 @@ class IKnownFoldersStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -76,7 +76,7 @@ class IKnownFoldersStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -104,7 +104,7 @@ class IKnownFoldersStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/istoragefolder.dart
+++ b/packages/windows_storage/lib/src/istoragefolder.dart
@@ -256,7 +256,8 @@ class IStorageFolder extends IInspectable implements IStorageItem {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<List<StorageFile>> getFilesAsyncOverloadDefaultOptionsStartAndCount() {
+  Future<List<StorageFile?>>
+      getFilesAsyncOverloadDefaultOptionsStartAndCount() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -276,7 +277,7 @@ class IStorageFolder extends IInspectable implements IStorageItem {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFile>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFile?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFile.fromPtr,
@@ -284,7 +285,7 @@ class IStorageFolder extends IInspectable implements IStorageItem {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<StorageFolder>>
+  Future<List<StorageFolder?>>
       getFoldersAsyncOverloadDefaultOptionsStartAndCount() {
     final retValuePtr = calloc<COMObject>();
 
@@ -305,7 +306,7 @@ class IStorageFolder extends IInspectable implements IStorageItem {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFolder.fromPtr,
@@ -313,7 +314,7 @@ class IStorageFolder extends IInspectable implements IStorageItem {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<IStorageItem>> getItemsAsyncOverloadDefaultStartAndCount() {
+  Future<List<IStorageItem?>> getItemsAsyncOverloadDefaultStartAndCount() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -333,7 +334,7 @@ class IStorageFolder extends IInspectable implements IStorageItem {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: IStorageItem.fromPtr,

--- a/packages/windows_storage/lib/src/istoragefolder3.dart
+++ b/packages/windows_storage/lib/src/istoragefolder3.dart
@@ -47,7 +47,7 @@ class IStorageFolder3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/istorageitemproperties.dart
+++ b/packages/windows_storage/lib/src/istorageitemproperties.dart
@@ -217,7 +217,7 @@ class IStorageItemProperties extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/istorageitempropertieswithprovider.dart
+++ b/packages/windows_storage/lib/src/istorageitempropertieswithprovider.dart
@@ -55,7 +55,7 @@ class IStorageItemPropertiesWithProvider extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/istoragelibrarychangereader.dart
+++ b/packages/windows_storage/lib/src/istoragelibrarychangereader.dart
@@ -29,7 +29,7 @@ class IStorageLibraryChangeReader extends IInspectable {
       IStorageLibraryChangeReader.fromPtr(
           interface.toInterface(IID_IStorageLibraryChangeReader));
 
-  Future<List<StorageLibraryChange>> readBatchAsync() {
+  Future<List<StorageLibraryChange?>> readBatchAsync() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -50,7 +50,7 @@ class IStorageLibraryChangeReader extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVectorView<StorageLibraryChange>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVectorView<StorageLibraryChange?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVectorView.fromPtr(ptr,
                 creator: StorageLibraryChange.fromPtr,
                 iterableIid: '{87c15dfc-0c5e-518b-9206-97d3d9823c61}'));

--- a/packages/windows_storage/lib/src/istoragelibrarychangetracker.dart
+++ b/packages/windows_storage/lib/src/istoragelibrarychangetracker.dart
@@ -49,7 +49,7 @@ class IStorageLibraryChangeTracker extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/istoragestreamtransaction.dart
+++ b/packages/windows_storage/lib/src/istoragestreamtransaction.dart
@@ -48,7 +48,7 @@ class IStorageStreamTransaction extends IInspectable implements IClosable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
+++ b/packages/windows_storage/lib/src/iuserdatapathsstatics.dart
@@ -54,7 +54,7 @@ class IUserDataPathsStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -82,7 +82,7 @@ class IUserDataPathsStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/fileopenpicker.dart
+++ b/packages/windows_storage/lib/src/pickers/fileopenpicker.dart
@@ -78,7 +78,7 @@ class FileOpenPicker extends IInspectable
       _iFileOpenPicker.pickSingleFileAsync();
 
   @override
-  Future<List<StorageFile>> pickMultipleFilesAsync() =>
+  Future<List<StorageFile?>> pickMultipleFilesAsync() =>
       _iFileOpenPicker.pickMultipleFilesAsync();
 
   late final _iFileOpenPicker3 = IFileOpenPicker3.from(this);

--- a/packages/windows_storage/lib/src/pickers/ifileopenpicker.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpicker.dart
@@ -248,7 +248,7 @@ class IFileOpenPicker extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<List<StorageFile>> pickMultipleFilesAsync() {
+  Future<List<StorageFile?>> pickMultipleFilesAsync() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -268,7 +268,7 @@ class IFileOpenPicker extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFile>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFile?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFile.fromPtr,

--- a/packages/windows_storage/lib/src/pickers/ifileopenpicker3.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpicker3.dart
@@ -46,7 +46,7 @@ class IFileOpenPicker3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpickerstatics2.dart
@@ -54,7 +54,7 @@ class IFileOpenPickerStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifilesavepicker.dart
+++ b/packages/windows_storage/lib/src/pickers/ifilesavepicker.dart
@@ -253,7 +253,7 @@ class IFileSavePicker extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifilesavepicker4.dart
+++ b/packages/windows_storage/lib/src/pickers/ifilesavepicker4.dart
@@ -46,7 +46,7 @@ class IFileSavePicker4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifilesavepickerstatics.dart
+++ b/packages/windows_storage/lib/src/pickers/ifilesavepickerstatics.dart
@@ -54,7 +54,7 @@ class IFileSavePickerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifolderpicker3.dart
+++ b/packages/windows_storage/lib/src/pickers/ifolderpicker3.dart
@@ -46,7 +46,7 @@ class IFolderPicker3 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/pickers/ifolderpickerstatics.dart
+++ b/packages/windows_storage/lib/src/pickers/ifolderpickerstatics.dart
@@ -54,7 +54,7 @@ class IFolderPickerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/search/istoragefilequeryresult.dart
+++ b/packages/windows_storage/lib/src/search/istoragefilequeryresult.dart
@@ -32,7 +32,7 @@ class IStorageFileQueryResult extends IInspectable
       IStorageFileQueryResult.fromPtr(
           interface.toInterface(IID_IStorageFileQueryResult));
 
-  Future<List<StorageFile>> getFilesAsync(
+  Future<List<StorageFile?>> getFilesAsync(
       int startIndex, int maxNumberOfItems) {
     final retValuePtr = calloc<COMObject>();
 
@@ -57,7 +57,7 @@ class IStorageFileQueryResult extends IInspectable
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFile>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFile?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFile.fromPtr,
@@ -65,7 +65,7 @@ class IStorageFileQueryResult extends IInspectable
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<StorageFile>> getFilesAsyncDefaultStartAndCount() {
+  Future<List<StorageFile?>> getFilesAsyncDefaultStartAndCount() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -85,7 +85,7 @@ class IStorageFileQueryResult extends IInspectable
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFile>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFile?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFile.fromPtr,

--- a/packages/windows_storage/lib/src/search/istoragefolderqueryoperations.dart
+++ b/packages/windows_storage/lib/src/search/istoragefolderqueryoperations.dart
@@ -83,7 +83,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -112,7 +112,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -146,7 +146,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -174,7 +174,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -203,7 +203,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -237,7 +237,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -265,7 +265,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -299,7 +299,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -307,7 +307,7 @@ class IStorageFolderQueryOperations extends IInspectable {
     return StorageItemQueryResult.fromPtr(retValuePtr);
   }
 
-  Future<List<StorageFile>> getFilesAsync(
+  Future<List<StorageFile?>> getFilesAsync(
       CommonFileQuery query, int startIndex, int maxItemsToRetrieve) {
     final retValuePtr = calloc<COMObject>();
 
@@ -337,7 +337,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFile>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFile?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFile.fromPtr,
@@ -345,7 +345,7 @@ class IStorageFolderQueryOperations extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<StorageFile>> getFilesAsyncOverloadDefaultStartAndCount(
+  Future<List<StorageFile?>> getFilesAsyncOverloadDefaultStartAndCount(
       CommonFileQuery query) {
     final retValuePtr = calloc<COMObject>();
 
@@ -367,7 +367,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFile>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFile?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFile.fromPtr,
@@ -375,7 +375,7 @@ class IStorageFolderQueryOperations extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<StorageFolder>> getFoldersAsync(
+  Future<List<StorageFolder?>> getFoldersAsync(
       CommonFolderQuery query, int startIndex, int maxItemsToRetrieve) {
     final retValuePtr = calloc<COMObject>();
 
@@ -405,7 +405,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFolder.fromPtr,
@@ -413,7 +413,7 @@ class IStorageFolderQueryOperations extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<StorageFolder>> getFoldersAsyncOverloadDefaultStartAndCount(
+  Future<List<StorageFolder?>> getFoldersAsyncOverloadDefaultStartAndCount(
       CommonFolderQuery query) {
     final retValuePtr = calloc<COMObject>();
 
@@ -435,7 +435,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFolder.fromPtr,
@@ -443,7 +443,7 @@ class IStorageFolderQueryOperations extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<IStorageItem>> getItemsAsync(
+  Future<List<IStorageItem?>> getItemsAsync(
       int startIndex, int maxItemsToRetrieve) {
     final retValuePtr = calloc<COMObject>();
 
@@ -468,7 +468,7 @@ class IStorageFolderQueryOperations extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: IStorageItem.fromPtr,

--- a/packages/windows_storage/lib/src/search/istoragefolderqueryresult.dart
+++ b/packages/windows_storage/lib/src/search/istoragefolderqueryresult.dart
@@ -31,7 +31,7 @@ class IStorageFolderQueryResult extends IInspectable
       IStorageFolderQueryResult.fromPtr(
           interface.toInterface(IID_IStorageFolderQueryResult));
 
-  Future<List<StorageFolder>> getFoldersAsync(
+  Future<List<StorageFolder?>> getFoldersAsync(
       int startIndex, int maxNumberOfItems) {
     final retValuePtr = calloc<COMObject>();
 
@@ -56,7 +56,7 @@ class IStorageFolderQueryResult extends IInspectable
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFolder.fromPtr,
@@ -64,7 +64,7 @@ class IStorageFolderQueryResult extends IInspectable
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<StorageFolder>> getFoldersAsyncDefaultStartAndCount() {
+  Future<List<StorageFolder?>> getFoldersAsyncDefaultStartAndCount() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -84,7 +84,7 @@ class IStorageFolderQueryResult extends IInspectable
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<StorageFolder?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: StorageFolder.fromPtr,

--- a/packages/windows_storage/lib/src/search/istorageitemqueryresult.dart
+++ b/packages/windows_storage/lib/src/search/istorageitemqueryresult.dart
@@ -32,7 +32,7 @@ class IStorageItemQueryResult extends IInspectable
       IStorageItemQueryResult.fromPtr(
           interface.toInterface(IID_IStorageItemQueryResult));
 
-  Future<List<IStorageItem>> getItemsAsync(
+  Future<List<IStorageItem?>> getItemsAsync(
       int startIndex, int maxNumberOfItems) {
     final retValuePtr = calloc<COMObject>();
 
@@ -57,7 +57,7 @@ class IStorageItemQueryResult extends IInspectable
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: IStorageItem.fromPtr,
@@ -65,7 +65,7 @@ class IStorageItemQueryResult extends IInspectable
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<IStorageItem>> getItemsAsyncDefaultStartAndCount() {
+  Future<List<IStorageItem?>> getItemsAsyncDefaultStartAndCount() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -85,7 +85,7 @@ class IStorageItemQueryResult extends IInspectable
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<IStorageItem?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: IStorageItem.fromPtr,

--- a/packages/windows_storage/lib/src/search/istoragequeryresultbase.dart
+++ b/packages/windows_storage/lib/src/search/istoragequeryresultbase.dart
@@ -74,7 +74,7 @@ class IStorageQueryResultBase extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -218,7 +218,7 @@ class IStorageQueryResultBase extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/search/storagefilequeryresult.dart
+++ b/packages/windows_storage/lib/src/search/storagefilequeryresult.dart
@@ -37,12 +37,12 @@ class StorageFileQueryResult extends IInspectable
   late final _iStorageFileQueryResult = IStorageFileQueryResult.from(this);
 
   @override
-  Future<List<StorageFile>> getFilesAsync(
+  Future<List<StorageFile?>> getFilesAsync(
           int startIndex, int maxNumberOfItems) =>
       _iStorageFileQueryResult.getFilesAsync(startIndex, maxNumberOfItems);
 
   @override
-  Future<List<StorageFile>> getFilesAsyncDefaultStartAndCount() =>
+  Future<List<StorageFile?>> getFilesAsyncDefaultStartAndCount() =>
       _iStorageFileQueryResult.getFilesAsyncDefaultStartAndCount();
 
   late final _iStorageQueryResultBase = IStorageQueryResultBase.from(this);

--- a/packages/windows_storage/lib/src/search/storagefolderqueryresult.dart
+++ b/packages/windows_storage/lib/src/search/storagefolderqueryresult.dart
@@ -31,12 +31,12 @@ class StorageFolderQueryResult extends IInspectable
   late final _iStorageFolderQueryResult = IStorageFolderQueryResult.from(this);
 
   @override
-  Future<List<StorageFolder>> getFoldersAsync(
+  Future<List<StorageFolder?>> getFoldersAsync(
           int startIndex, int maxNumberOfItems) =>
       _iStorageFolderQueryResult.getFoldersAsync(startIndex, maxNumberOfItems);
 
   @override
-  Future<List<StorageFolder>> getFoldersAsyncDefaultStartAndCount() =>
+  Future<List<StorageFolder?>> getFoldersAsyncDefaultStartAndCount() =>
       _iStorageFolderQueryResult.getFoldersAsyncDefaultStartAndCount();
 
   late final _iStorageQueryResultBase = IStorageQueryResultBase.from(this);

--- a/packages/windows_storage/lib/src/search/storageitemqueryresult.dart
+++ b/packages/windows_storage/lib/src/search/storageitemqueryresult.dart
@@ -32,12 +32,12 @@ class StorageItemQueryResult extends IInspectable
   late final _iStorageItemQueryResult = IStorageItemQueryResult.from(this);
 
   @override
-  Future<List<IStorageItem>> getItemsAsync(
+  Future<List<IStorageItem?>> getItemsAsync(
           int startIndex, int maxNumberOfItems) =>
       _iStorageItemQueryResult.getItemsAsync(startIndex, maxNumberOfItems);
 
   @override
-  Future<List<IStorageItem>> getItemsAsyncDefaultStartAndCount() =>
+  Future<List<IStorageItem?>> getItemsAsyncDefaultStartAndCount() =>
       _iStorageItemQueryResult.getItemsAsyncDefaultStartAndCount();
 
   late final _iStorageQueryResultBase = IStorageQueryResultBase.from(this);

--- a/packages/windows_storage/lib/src/storagefolder.dart
+++ b/packages/windows_storage/lib/src/storagefolder.dart
@@ -110,17 +110,17 @@ class StorageFolder extends IInspectable
       _iStorageFolder.getItemAsync(name);
 
   @override
-  Future<List<StorageFile>>
+  Future<List<StorageFile?>>
       getFilesAsyncOverloadDefaultOptionsStartAndCount() =>
           _iStorageFolder.getFilesAsyncOverloadDefaultOptionsStartAndCount();
 
   @override
-  Future<List<StorageFolder>>
+  Future<List<StorageFolder?>>
       getFoldersAsyncOverloadDefaultOptionsStartAndCount() =>
           _iStorageFolder.getFoldersAsyncOverloadDefaultOptionsStartAndCount();
 
   @override
-  Future<List<IStorageItem>> getItemsAsyncOverloadDefaultStartAndCount() =>
+  Future<List<IStorageItem?>> getItemsAsyncOverloadDefaultStartAndCount() =>
       _iStorageFolder.getItemsAsyncOverloadDefaultStartAndCount();
 
   late final _iStorageItem = IStorageItem.from(this);
@@ -203,31 +203,31 @@ class StorageFolder extends IInspectable
       _iStorageFolderQueryOperations.createItemQueryWithOptions(queryOptions);
 
   @override
-  Future<List<StorageFile>> getFilesAsync(
+  Future<List<StorageFile?>> getFilesAsync(
           CommonFileQuery query, int startIndex, int maxItemsToRetrieve) =>
       _iStorageFolderQueryOperations.getFilesAsync(
           query, startIndex, maxItemsToRetrieve);
 
   @override
-  Future<List<StorageFile>> getFilesAsyncOverloadDefaultStartAndCount(
+  Future<List<StorageFile?>> getFilesAsyncOverloadDefaultStartAndCount(
           CommonFileQuery query) =>
       _iStorageFolderQueryOperations
           .getFilesAsyncOverloadDefaultStartAndCount(query);
 
   @override
-  Future<List<StorageFolder>> getFoldersAsync(
+  Future<List<StorageFolder?>> getFoldersAsync(
           CommonFolderQuery query, int startIndex, int maxItemsToRetrieve) =>
       _iStorageFolderQueryOperations.getFoldersAsync(
           query, startIndex, maxItemsToRetrieve);
 
   @override
-  Future<List<StorageFolder>> getFoldersAsyncOverloadDefaultStartAndCount(
+  Future<List<StorageFolder?>> getFoldersAsyncOverloadDefaultStartAndCount(
           CommonFolderQuery query) =>
       _iStorageFolderQueryOperations
           .getFoldersAsyncOverloadDefaultStartAndCount(query);
 
   @override
-  Future<List<IStorageItem>> getItemsAsync(
+  Future<List<IStorageItem?>> getItemsAsync(
           int startIndex, int maxItemsToRetrieve) =>
       _iStorageFolderQueryOperations.getItemsAsync(
           startIndex, maxItemsToRetrieve);

--- a/packages/windows_storage/lib/src/storagelibrarychangereader.dart
+++ b/packages/windows_storage/lib/src/storagelibrarychangereader.dart
@@ -29,7 +29,7 @@ class StorageLibraryChangeReader extends IInspectable
       IStorageLibraryChangeReader.from(this);
 
   @override
-  Future<List<StorageLibraryChange>> readBatchAsync() =>
+  Future<List<StorageLibraryChange?>> readBatchAsync() =>
       _iStorageLibraryChangeReader.readBatchAsync();
 
   @override

--- a/packages/windows_storage/lib/src/streams/ibufferstatics.dart
+++ b/packages/windows_storage/lib/src/streams/ibufferstatics.dart
@@ -53,7 +53,7 @@ class IBufferStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -86,7 +86,7 @@ class IBufferStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/streams/idatareader.dart
+++ b/packages/windows_storage/lib/src/streams/idatareader.dart
@@ -241,7 +241,7 @@ class IDataReader extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -611,7 +611,7 @@ class IDataReader extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -639,7 +639,7 @@ class IDataReader extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/streams/idatareaderstatics.dart
+++ b/packages/windows_storage/lib/src/streams/idatareaderstatics.dart
@@ -53,7 +53,7 @@ class IDataReaderStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/streams/idatawriter.dart
+++ b/packages/windows_storage/lib/src/streams/idatawriter.dart
@@ -512,7 +512,7 @@ class IDataWriter extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -540,7 +540,7 @@ class IDataWriter extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/streams/ipropertysetserializer.dart
+++ b/packages/windows_storage/lib/src/streams/ipropertysetserializer.dart
@@ -54,7 +54,7 @@ class IPropertySetSerializer extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/streams/irandomaccessstream.dart
+++ b/packages/windows_storage/lib/src/streams/irandomaccessstream.dart
@@ -94,7 +94,7 @@ class IRandomAccessStream extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -123,7 +123,7 @@ class IRandomAccessStream extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -191,7 +191,7 @@ class IRandomAccessStream extends IInspectable
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/lib/src/streams/irandomaccessstreamreferencestatics.dart
+++ b/packages/windows_storage/lib/src/streams/irandomaccessstreamreferencestatics.dart
@@ -56,7 +56,7 @@ class IRandomAccessStreamReferenceStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -89,7 +89,7 @@ class IRandomAccessStreamReferenceStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -122,7 +122,7 @@ class IRandomAccessStreamReferenceStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_storage/test/collections_test.dart
+++ b/packages/windows_storage/test/collections_test.dart
@@ -40,6 +40,7 @@ void main() {
       final vector = getVector()
         ..append('.jpg')
         ..append('.jpeg');
+      expect(vector.size, equals(2));
       expect(vector.getAt(0), equals('.jpg'));
       expect(vector.getAt(1), equals('.jpeg'));
     });

--- a/packages/windows_system/example/launcher.dart
+++ b/packages/windows_system/example/launcher.dart
@@ -40,7 +40,7 @@ void main() async {
   if (handlers.isNotEmpty) {
     print('Found ${handlers.length} handler(s) for ".html" files:');
     for (final handler in handlers) {
-      print(' - ${handler.displayInfo?.displayName}');
+      print(' - ${handler?.displayInfo?.displayName}');
     }
   }
 

--- a/packages/windows_system/lib/src/folderlauncheroptions.dart
+++ b/packages/windows_system/lib/src/folderlauncheroptions.dart
@@ -33,7 +33,7 @@ class FolderLauncherOptions extends IInspectable
   late final _iFolderLauncherOptions = IFolderLauncherOptions.from(this);
 
   @override
-  IVector<IStorageItem> get itemsToSelect =>
+  IVector<IStorageItem?> get itemsToSelect =>
       _iFolderLauncherOptions.itemsToSelect;
 
   late final _iLauncherViewOptions = ILauncherViewOptions.from(this);

--- a/packages/windows_system/lib/src/ifolderlauncheroptions.dart
+++ b/packages/windows_system/lib/src/ifolderlauncheroptions.dart
@@ -27,7 +27,7 @@ class IFolderLauncherOptions extends IInspectable {
       IFolderLauncherOptions.fromPtr(
           interface.toInterface(IID_IFolderLauncherOptions));
 
-  IVector<IStorageItem> get itemsToSelect {
+  IVector<IStorageItem?> get itemsToSelect {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable

--- a/packages/windows_system/lib/src/ilauncheroptions.dart
+++ b/packages/windows_system/lib/src/ilauncheroptions.dart
@@ -123,7 +123,7 @@ class ILauncherOptions extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -245,7 +245,7 @@ class ILauncherOptions extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_system/lib/src/ilauncheroptions2.dart
+++ b/packages/windows_system/lib/src/ilauncheroptions2.dart
@@ -93,7 +93,7 @@ class ILauncherOptions2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_system/lib/src/ilauncherstatics2.dart
+++ b/packages/windows_system/lib/src/ilauncherstatics2.dart
@@ -302,7 +302,7 @@ class ILauncherStatics2 extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<List<AppInfo>> findUriSchemeHandlersAsync(String scheme) {
+  Future<List<AppInfo?>> findUriSchemeHandlersAsync(String scheme) {
     final retValuePtr = calloc<COMObject>();
     final schemeHString = scheme.toHString();
 
@@ -326,7 +326,7 @@ class ILauncherStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<AppInfo>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<AppInfo?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: AppInfo.fromPtr,
@@ -334,7 +334,7 @@ class ILauncherStatics2 extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<AppInfo>> findUriSchemeHandlersWithLaunchUriTypeAsync(
+  Future<List<AppInfo?>> findUriSchemeHandlersWithLaunchUriTypeAsync(
       String scheme, LaunchQuerySupportType launchQuerySupportType) {
     final retValuePtr = calloc<COMObject>();
     final schemeHString = scheme.toHString();
@@ -365,7 +365,7 @@ class ILauncherStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<AppInfo>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<AppInfo?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: AppInfo.fromPtr,
@@ -373,7 +373,7 @@ class ILauncherStatics2 extends IInspectable {
     return asyncOperation.toFuture(() => asyncOperation.getResults().toList());
   }
 
-  Future<List<AppInfo>> findFileHandlersAsync(String extension) {
+  Future<List<AppInfo?>> findFileHandlersAsync(String extension) {
     final retValuePtr = calloc<COMObject>();
     final extensionHString = extension.toHString();
 
@@ -397,7 +397,7 @@ class ILauncherStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<AppInfo>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<AppInfo?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: AppInfo.fromPtr,

--- a/packages/windows_system/lib/src/ilauncherstatics4.dart
+++ b/packages/windows_system/lib/src/ilauncherstatics4.dart
@@ -101,7 +101,7 @@ class ILauncherStatics4 extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<List<AppInfo>> findAppUriHandlersAsync(Uri? uri) {
+  Future<List<AppInfo?>> findAppUriHandlersAsync(Uri? uri) {
     final retValuePtr = calloc<COMObject>();
     final uriUri = uri?.toWinRTUri();
 
@@ -126,7 +126,7 @@ class ILauncherStatics4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<AppInfo>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<AppInfo?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: AppInfo.fromPtr,

--- a/packages/windows_system/lib/src/ilauncheruioptions.dart
+++ b/packages/windows_system/lib/src/ilauncheruioptions.dart
@@ -46,7 +46,7 @@ class ILauncherUIOptions extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -92,7 +92,7 @@ class ILauncherUIOptions extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_system/lib/src/iuserstatics.dart
+++ b/packages/windows_system/lib/src/iuserstatics.dart
@@ -50,7 +50,7 @@ class IUserStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -58,7 +58,7 @@ class IUserStatics extends IInspectable {
     return UserWatcher.fromPtr(retValuePtr);
   }
 
-  Future<List<User>> findAllAsync() {
+  Future<List<User?>> findAllAsync() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -78,7 +78,7 @@ class IUserStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<User>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<User?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: User.fromPtr,
@@ -88,7 +88,7 @@ class IUserStatics extends IInspectable {
 
   @Deprecated(
       "FindAllAsyncByType is deprecated and might not function consistently on all platforms. Instead, use FindAllAsync or GetDefault.")
-  Future<List<User>> findAllAsyncByType(UserType type) {
+  Future<List<User?>> findAllAsyncByType(UserType type) {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -109,7 +109,7 @@ class IUserStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<User>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<User?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: User.fromPtr,
@@ -119,7 +119,7 @@ class IUserStatics extends IInspectable {
 
   @Deprecated(
       "FindAllAsyncByTypeAndStatus is deprecated and might not function consistently on all platforms. Instead, use FindAllAsync or GetDefault.")
-  Future<List<User>> findAllAsyncByTypeAndStatus(
+  Future<List<User?>> findAllAsyncByTypeAndStatus(
       UserType type, UserAuthenticationStatus status) {
     final retValuePtr = calloc<COMObject>();
 
@@ -141,7 +141,7 @@ class IUserStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final asyncOperation = IAsyncOperation<IVectorView<User>>.fromPtr(
+    final asyncOperation = IAsyncOperation<IVectorView<User?>>.fromPtr(
         retValuePtr,
         creator: (ptr) => IVectorView.fromPtr(ptr,
             creator: User.fromPtr,
@@ -176,7 +176,7 @@ class IUserStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_system/lib/src/iuserstatics2.dart
+++ b/packages/windows_system/lib/src/iuserstatics2.dart
@@ -47,7 +47,7 @@ class IUserStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_system/lib/src/launcher.dart
+++ b/packages/windows_system/lib/src/launcher.dart
@@ -105,19 +105,19 @@ class Launcher extends IInspectable {
               .queryFileSupportWithPackageFamilyNameAsync(
                   file, packageFamilyName);
 
-  static Future<List<AppInfo>> findUriSchemeHandlersAsync(String scheme) =>
+  static Future<List<AppInfo?>> findUriSchemeHandlersAsync(String scheme) =>
       createActivationFactory(
               ILauncherStatics2.fromPtr, _className, IID_ILauncherStatics2)
           .findUriSchemeHandlersAsync(scheme);
 
-  static Future<List<AppInfo>> findUriSchemeHandlersWithLaunchUriTypeAsync(
+  static Future<List<AppInfo?>> findUriSchemeHandlersWithLaunchUriTypeAsync(
           String scheme, LaunchQuerySupportType launchQuerySupportType) =>
       createActivationFactory(
               ILauncherStatics2.fromPtr, _className, IID_ILauncherStatics2)
           .findUriSchemeHandlersWithLaunchUriTypeAsync(
               scheme, launchQuerySupportType);
 
-  static Future<List<AppInfo>> findFileHandlersAsync(String extension) =>
+  static Future<List<AppInfo?>> findFileHandlersAsync(String extension) =>
       createActivationFactory(
               ILauncherStatics2.fromPtr, _className, IID_ILauncherStatics2)
           .findFileHandlersAsync(extension);
@@ -146,7 +146,7 @@ class Launcher extends IInspectable {
               .queryAppUriSupportWithPackageFamilyNameAsync(
                   uri, packageFamilyName);
 
-  static Future<List<AppInfo>> findAppUriHandlersAsync(Uri? uri) =>
+  static Future<List<AppInfo?>> findAppUriHandlersAsync(Uri? uri) =>
       createActivationFactory(
               ILauncherStatics4.fromPtr, _className, IID_ILauncherStatics4)
           .findAppUriHandlersAsync(uri);

--- a/packages/windows_system/lib/src/user.dart
+++ b/packages/windows_system/lib/src/user.dart
@@ -37,20 +37,20 @@ class User extends IInspectable implements IUser, IUser2 {
           IUserStatics.fromPtr, _className, IID_IUserStatics)
       .createWatcher();
 
-  static Future<List<User>> findAllAsync() => createActivationFactory(
+  static Future<List<User?>> findAllAsync() => createActivationFactory(
           IUserStatics.fromPtr, _className, IID_IUserStatics)
       .findAllAsync();
 
   @Deprecated(
       "FindAllAsyncByType is deprecated and might not function consistently on all platforms. Instead, use FindAllAsync or GetDefault.")
-  static Future<List<User>> findAllAsyncByType(UserType type) =>
+  static Future<List<User?>> findAllAsyncByType(UserType type) =>
       createActivationFactory(
               IUserStatics.fromPtr, _className, IID_IUserStatics)
           .findAllAsyncByType(type);
 
   @Deprecated(
       "FindAllAsyncByTypeAndStatus is deprecated and might not function consistently on all platforms. Instead, use FindAllAsync or GetDefault.")
-  static Future<List<User>> findAllAsyncByTypeAndStatus(
+  static Future<List<User?>> findAllAsyncByTypeAndStatus(
           UserType type, UserAuthenticationStatus status) =>
       createActivationFactory(
               IUserStatics.fromPtr, _className, IID_IUserStatics)

--- a/packages/windows_ui/lib/src/notifications/ischeduledtoastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/ischeduledtoastnotification.dart
@@ -48,7 +48,7 @@ class IScheduledToastNotification extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -100,7 +100,7 @@ class IScheduledToastNotification extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/ischeduledtoastnotification4.dart
+++ b/packages/windows_ui/lib/src/notifications/ischeduledtoastnotification4.dart
@@ -47,7 +47,7 @@ class IScheduledToastNotification4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastcollection.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastcollection.dart
@@ -164,7 +164,7 @@ class IToastCollection extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastcollectionmanager.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastcollectionmanager.dart
@@ -57,7 +57,7 @@ class IToastCollectionManager extends IInspectable {
     return IAsyncAction.fromPtr(retValuePtr).toFuture();
   }
 
-  Future<List<ToastCollection>> findAllToastCollectionsAsync() {
+  Future<List<ToastCollection?>> findAllToastCollectionsAsync() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -78,7 +78,7 @@ class IToastCollectionManager extends IInspectable {
     }
 
     final asyncOperation =
-        IAsyncOperation<IVectorView<ToastCollection>>.fromPtr(retValuePtr,
+        IAsyncOperation<IVectorView<ToastCollection?>>.fromPtr(retValuePtr,
             creator: (ptr) => IVectorView.fromPtr(ptr,
                 creator: ToastCollection.fromPtr,
                 iterableIid: '{8928d527-db5d-5a10-ae9b-430fa0906e74}'));
@@ -191,7 +191,7 @@ class IToastCollectionManager extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification.dart
@@ -48,7 +48,7 @@ class IToastNotification extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -92,7 +92,7 @@ class IToastNotification extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotification4.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotification4.dart
@@ -49,7 +49,7 @@ class IToastNotification4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationhistory2.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationhistory2.dart
@@ -28,7 +28,7 @@ class IToastNotificationHistory2 extends IInspectable {
       IToastNotificationHistory2.fromPtr(
           interface.toInterface(IID_IToastNotificationHistory2));
 
-  List<ToastNotification> getHistory() {
+  List<ToastNotification?> getHistory() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -48,13 +48,13 @@ class IToastNotificationHistory2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<ToastNotification>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<ToastNotification?>.fromPtr(retValuePtr,
         iterableIid: '{52c9428b-d37a-554d-bf55-b8685d5f552d}',
         creator: ToastNotification.fromPtr);
     return vectorView.toList();
   }
 
-  List<ToastNotification> getHistoryWithId(String applicationId) {
+  List<ToastNotification?> getHistoryWithId(String applicationId) {
     final retValuePtr = calloc<COMObject>();
     final applicationIdHString = applicationId.toHString();
 
@@ -81,7 +81,7 @@ class IToastNotificationHistory2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<ToastNotification>.fromPtr(retValuePtr,
+    final vectorView = IVectorView<ToastNotification?>.fromPtr(retValuePtr,
         iterableIid: '{52c9428b-d37a-554d-bf55-b8685d5f552d}',
         creator: ToastNotification.fromPtr);
     return vectorView.toList();

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerforuser.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerforuser.dart
@@ -51,7 +51,7 @@ class IToastNotificationManagerForUser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -86,7 +86,7 @@ class IToastNotificationManagerForUser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -114,7 +114,7 @@ class IToastNotificationManagerForUser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -142,7 +142,7 @@ class IToastNotificationManagerForUser extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerforuser2.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerforuser2.dart
@@ -118,7 +118,7 @@ class IToastNotificationManagerForUser2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -150,7 +150,7 @@ class IToastNotificationManagerForUser2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics.dart
@@ -51,7 +51,7 @@ class IToastNotificationManagerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -86,7 +86,7 @@ class IToastNotificationManagerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -115,7 +115,7 @@ class IToastNotificationManagerStatics extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics2.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics2.dart
@@ -49,7 +49,7 @@ class IToastNotificationManagerStatics2 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics4.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics4.dart
@@ -56,7 +56,7 @@ class IToastNotificationManagerStatics4 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics5.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationmanagerstatics5.dart
@@ -49,7 +49,7 @@ class IToastNotificationManagerStatics5 extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/notifications/itoastnotifier.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotifier.dart
@@ -131,7 +131,7 @@ class IToastNotifier extends IInspectable {
     if (FAILED(hr)) throw WindowsException(hr);
   }
 
-  List<ScheduledToastNotification> getScheduledToastNotifications() {
+  List<ScheduledToastNotification?> getScheduledToastNotifications() {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -151,7 +151,7 @@ class IToastNotifier extends IInspectable {
       throw WindowsException(hr);
     }
 
-    final vectorView = IVectorView<ScheduledToastNotification>.fromPtr(
+    final vectorView = IVectorView<ScheduledToastNotification?>.fromPtr(
         retValuePtr,
         iterableIid: '{7a7b2a51-c182-5846-a861-4f9c036f24ad}',
         creator: ScheduledToastNotification.fromPtr);

--- a/packages/windows_ui/lib/src/notifications/toastcollectionmanager.dart
+++ b/packages/windows_ui/lib/src/notifications/toastcollectionmanager.dart
@@ -32,7 +32,7 @@ class ToastCollectionManager extends IInspectable
       _iToastCollectionManager.saveToastCollectionAsync(collection);
 
   @override
-  Future<List<ToastCollection>> findAllToastCollectionsAsync() =>
+  Future<List<ToastCollection?>> findAllToastCollectionsAsync() =>
       _iToastCollectionManager.findAllToastCollectionsAsync();
 
   @override

--- a/packages/windows_ui/lib/src/notifications/toastnotificationhistory.dart
+++ b/packages/windows_ui/lib/src/notifications/toastnotificationhistory.dart
@@ -29,11 +29,11 @@ class ToastNotificationHistory extends IInspectable
       IToastNotificationHistory2.from(this);
 
   @override
-  List<ToastNotification> getHistory() =>
+  List<ToastNotification?> getHistory() =>
       _iToastNotificationHistory2.getHistory();
 
   @override
-  List<ToastNotification> getHistoryWithId(String applicationId) =>
+  List<ToastNotification?> getHistoryWithId(String applicationId) =>
       _iToastNotificationHistory2.getHistoryWithId(applicationId);
 
   late final _iToastNotificationHistory = IToastNotificationHistory.from(this);

--- a/packages/windows_ui/lib/src/notifications/toastnotifier.dart
+++ b/packages/windows_ui/lib/src/notifications/toastnotifier.dart
@@ -53,7 +53,7 @@ class ToastNotifier extends IInspectable
       _iToastNotifier.removeFromSchedule(scheduledToast);
 
   @override
-  List<ScheduledToastNotification> getScheduledToastNotifications() =>
+  List<ScheduledToastNotification?> getScheduledToastNotifications() =>
       _iToastNotifier.getScheduledToastNotifications();
 
   late final _iToastNotifier2 = IToastNotifier2.from(this);

--- a/packages/windows_ui/lib/src/popups/imessagedialog.dart
+++ b/packages/windows_ui/lib/src/popups/imessagedialog.dart
@@ -75,7 +75,7 @@ class IMessageDialog extends IInspectable {
     }
   }
 
-  IVector<IUICommand> get commands {
+  IVector<IUICommand?> get commands {
     final retValuePtr = calloc<COMObject>();
 
     final hr = ptr.ref.vtable

--- a/packages/windows_ui/lib/src/popups/iuicommand.dart
+++ b/packages/windows_ui/lib/src/popups/iuicommand.dart
@@ -131,7 +131,7 @@ class IUICommand extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/popups/messagedialog.dart
+++ b/packages/windows_ui/lib/src/popups/messagedialog.dart
@@ -44,7 +44,7 @@ class MessageDialog extends IInspectable implements IMessageDialog {
   set title(String value) => _iMessageDialog.title = value;
 
   @override
-  IVector<IUICommand> get commands => _iMessageDialog.commands;
+  IVector<IUICommand?> get commands => _iMessageDialog.commands;
 
   @override
   int get defaultCommandIndex => _iMessageDialog.defaultCommandIndex;

--- a/packages/windows_ui/lib/src/uiautomation/core/iautomationremoteoperationresult.dart
+++ b/packages/windows_ui/lib/src/uiautomation/core/iautomationremoteoperationresult.dart
@@ -165,7 +165,7 @@ class IAutomationRemoteOperationResult extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/uiautomation/core/icoreautomationremoteoperation.dart
+++ b/packages/windows_ui/lib/src/uiautomation/core/icoreautomationremoteoperation.dart
@@ -166,7 +166,7 @@ class ICoreAutomationRemoteOperation extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/uiautomation/core/icoreautomationremoteoperationcontext.dart
+++ b/packages/windows_ui/lib/src/uiautomation/core/icoreautomationremoteoperationcontext.dart
@@ -57,7 +57,7 @@ class ICoreAutomationRemoteOperationContext extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/uiautomation/core/iremoteautomationwindow.dart
+++ b/packages/windows_ui/lib/src/uiautomation/core/iremoteautomationwindow.dart
@@ -46,7 +46,7 @@ class IRemoteAutomationWindow extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/windows_ui/lib/src/uiautomation/iautomationconnectionboundobject.dart
+++ b/packages/windows_ui/lib/src/uiautomation/iautomationconnectionboundobject.dart
@@ -49,7 +49,7 @@ class IAutomationConnectionBoundObject extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/lib/src/constants/generic_types.dart
+++ b/packages/winrtgen/lib/src/constants/generic_types.dart
@@ -63,5 +63,6 @@ const _vectorTypeArgs = <TypeArg>[
   TypeArg.bool_, TypeArg.double, TypeArg.float, TypeArg.guid, //
   TypeArg.inspectable, TypeArg.int16, TypeArg.int32, TypeArg.int64, //
   TypeArg.string, TypeArg.uint8, TypeArg.uint16, TypeArg.uint32, //
-  TypeArg.uint64, TypeArg.uri, TypeArg.winrtEnum, TypeArg.winrtFlagsEnum //
+  TypeArg.uint64, TypeArg.nullableUri, TypeArg.winrtEnum, //
+  TypeArg.winrtFlagsEnum
 ];

--- a/packages/winrtgen/lib/src/projections/method_forwarders.dart
+++ b/packages/winrtgen/lib/src/projections/method_forwarders.dart
@@ -181,35 +181,6 @@ final class MethodForwardersProjection {
         continue;
       }
 
-      if (shortInterfaceName case 'IVector' || 'IVectorView') {
-        // Use custom forwarder for Append to make its parameter non-nullable.
-        if (methodProjection.name == 'Append') {
-          methods.add(vectorAppendForwarder());
-          continue;
-        }
-
-        // Use custom forwarder for IndexOf to make its value parameter
-        // non-nullable.
-        if (methodProjection.name == 'IndexOf') {
-          methods.add(vectorIndexOfForwarder());
-          continue;
-        }
-
-        // Use custom forwarder for InsertAt to make its value parameter
-        // non-nullable.
-        if (methodProjection.name == 'InsertAt') {
-          methods.add(vectorInsertAtForwarder());
-          continue;
-        }
-
-        // Use custom forwarder for SetAt to make its value parameter
-        // non-nullable.
-        if (methodProjection.name == 'SetAt') {
-          methods.add(vectorSetAtForwarder());
-          continue;
-        }
-      }
-
       methods.add(defaultForwarder(methodProjection));
     }
 
@@ -253,8 +224,7 @@ final class MethodForwardersProjection {
   // Custom method forwarders
 
   String jsonObjectInsertForwarder() {
-    final keyType = typeArgs.split(', ')[0];
-    final valueType = typeArgs.split(', ')[1];
+    final [keyType, valueType] = typeArgs.split(', ');
     return '''
   @override
   bool insert($keyType key, $valueType value) =>
@@ -273,47 +243,20 @@ final class MethodForwardersProjection {
 ''';
 
   String mapSubscriptAccessOperatorForwarder() {
-    final keyType = typeArgs.split(', ')[0];
-    final valueType = typeArgs.split(', ')[1];
+    final [keyType, valueType] = typeArgs.split(', ');
     return '''
   @override
   $valueType operator []($keyType key) => $fieldIdentifier[key];
-  ''';
+''';
   }
 
   String mapSubscriptAssignmentOperatorForwarder() {
-    final keyType = typeArgs.split(', ')[0];
-    final valueType = typeArgs.split(', ')[1];
+    final [keyType, valueType] = typeArgs.split(', ');
     return '''
   @override
-  void operator []=($keyType key, $valueType value) =>
-      $fieldIdentifier[key] = value;
-  ''';
+  void operator []=($keyType key, $valueType value) => $fieldIdentifier[key] = value;
+''';
   }
-
-  String vectorAppendForwarder() => '''
-  @override
-  void append(${stripQuestionMarkSuffix(typeArgs)} value) =>
-      $fieldIdentifier.append(value);
-''';
-
-  String vectorIndexOfForwarder() => '''
-  @override
-  bool indexOf(${stripQuestionMarkSuffix(typeArgs)} value, Pointer<Uint32> index) =>
-      $fieldIdentifier.indexOf(value, index);
-''';
-
-  String vectorInsertAtForwarder() => '''
-  @override
-  void insertAt(int index, ${stripQuestionMarkSuffix(typeArgs)} value) =>
-      $fieldIdentifier.insertAt(index, value);
-''';
-
-  String vectorSetAtForwarder() => '''
-  @override
-  void setAt(int index, ${stripQuestionMarkSuffix(typeArgs)} value) =>
-      $fieldIdentifier.setAt(index, value);
-''';
 
   String vectorFirstForwarder() => '''
   @override
@@ -327,20 +270,17 @@ final class MethodForwardersProjection {
 
   String vectorSubscriptAccessOperatorForwarder() => '''
   @override
-  ${stripQuestionMarkSuffix(typeArgs)} operator [](int index) =>
-      $fieldIdentifier[index];
+  $typeArgs operator [](int index) => $fieldIdentifier[index];
 ''';
 
   String vectorSubscriptAssignmentOperatorForwarder() => '''
   @override
-  void operator []=(int index, ${stripQuestionMarkSuffix(typeArgs)} value) =>
-      $fieldIdentifier[index] = value;
+  void operator []=(int index, $typeArgs value) => $fieldIdentifier[index] = value;
 ''';
 
   String vectorAddOperatorForwarder() => '''
   @override
-  List<$typeArgs> operator +(List<${stripQuestionMarkSuffix(typeArgs)}> other) =>
-      toList() + other;
+  List<$typeArgs> operator +(List<$typeArgs> other) => toList() + other;
 ''';
 
   @override

--- a/packages/winrtgen/lib/src/projections/types/generic.dart
+++ b/packages/winrtgen/lib/src/projections/types/generic.dart
@@ -110,7 +110,7 @@ mixin _GenericObjectMixin on MethodProjection {
 
   String get nullCheck => isNullable
       ? '''
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null as $typeParameter;
     }

--- a/packages/winrtgen/lib/src/projections/types/object.dart
+++ b/packages/winrtgen/lib/src/projections/types/object.dart
@@ -45,26 +45,13 @@ mixin _ObjectMixin on MethodProjection {
       return shortName;
     }
 
-    // IIterable.First() cannot return null.
-    if (method.name == 'First' && method.parent.isCollectionObject) {
-      return shortName;
-    }
-
-    // IVector(View).GetAt() cannot return null.
-    if (method.name == 'GetAt' &&
-        (method.parent.interfaces.any((interface) =>
-            (interface.typeSpec?.name.endsWith('IVector`1') ?? false) ||
-            (interface.typeSpec?.name.endsWith('IVectorView`1') ?? false)))) {
-      return shortName;
-    }
-
     return nullable(shortName);
   }
 
   String get nullCheck {
     if (!isNullable) return '';
     return '''
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }
@@ -239,7 +226,7 @@ final class ObjectListParameterProjection
   @override
   String get type => typeArgProjection.isObjectType
       ? 'List<Object?>'
-      : 'List<$typeArgShortName>';
+      : 'List<$typeArgShortName?>';
 
   @override
   String get fillArrayPreamble =>

--- a/packages/winrtgen/lib/src/projections/types/reference.dart
+++ b/packages/winrtgen/lib/src/projections/types/reference.dart
@@ -47,7 +47,7 @@ mixin _ReferenceMixin on MethodProjection {
   }
 
   String get nullCheck => '''
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/test/goldens/icalendar.golden
+++ b/packages/winrtgen/test/goldens/icalendar.golden
@@ -48,7 +48,7 @@ class ICalendar extends IInspectable {
       throw WindowsException(hr);
     }
 
-    if (retValuePtr.ref.isNull) {
+    if (retValuePtr.isNull) {
       free(retValuePtr);
       return null;
     }

--- a/packages/winrtgen/test/projections/getter_test.dart
+++ b/packages/winrtgen/test/projections/getter_test.dart
@@ -271,7 +271,7 @@ void main() {
           contains("iterableIid: '{fe2f3d47-5d47-5499-8374-430c7cda0204}'"));
     });
 
-    test('projects IReference<DateTime>', () {
+    test('projects IReference<DateTime?>', () {
       final projection = GetterProjection.fromTypeAndMethodName(
           'Windows.UI.Notifications.IToastNotification', 'get_ExpirationTime');
       expect(projection, isA<ReferenceGetterProjection>());

--- a/packages/winrtgen/test/projections/method_test.dart
+++ b/packages/winrtgen/test/projections/method_test.dart
@@ -188,7 +188,7 @@ void main() {
           'Windows.Foundation.Collections.StringMap', 'First');
       expect(projection, isA<ObjectMethodProjection>());
       expect(projection.returnType,
-          equals('IIterator<IKeyValuePair<String, String>>'));
+          equals('IIterator<IKeyValuePair<String, String>>?'));
       expect(
           projection.nativePrototype,
           equals(
@@ -198,7 +198,7 @@ void main() {
           equals(
               'int Function(VTablePointer lpVtbl, Pointer<COMObject> retValuePtr)'));
       expect(projection.methodHeader,
-          equals('IIterator<IKeyValuePair<String, String>> first()'));
+          equals('IIterator<IKeyValuePair<String, String>>? first()'));
     });
 
     test('projects IAsyncAction (1)', () {
@@ -307,7 +307,7 @@ void main() {
       expect(projection.methodHeader, equals('Map<String, String> getView()'));
     });
 
-    test('projects IReference<int>', () {
+    test('projects IReference<int?>', () {
       final projection = MethodProjection.fromTypeAndMethodName(
           'Windows.Networking.Connectivity.ConnectionProfile', 'GetSignalBars');
       expect(projection, isA<ReferenceMethodProjection>());

--- a/packages/winrtgen/test/projections/parameter_test.dart
+++ b/packages/winrtgen/test/projections/parameter_test.dart
@@ -122,14 +122,14 @@ void main() {
       expect(parameter.localIdentifier, equals('fileToReplacePtr'));
     });
 
-    test('projects IIterable<IKeyValuePair<String, Object?>>', () {
+    test('projects IIterable<IKeyValuePair<String, Object?>?>', () {
       final methodProjection = MethodProjection.fromTypeAndMethodName(
           'Windows.Storage.FileProperties.IStorageItemExtraProperties',
           'SavePropertiesAsync');
       final parameter = methodProjection.parameters.first;
       expect(parameter, isA<ObjectParameterProjection>());
-      expect(
-          parameter.type, equals('IIterable<IKeyValuePair<String, Object?>>?'));
+      expect(parameter.type,
+          equals('IIterable<IKeyValuePair<String, Object?>>?'));
       expect(
           parameter.preamble,
           equals(
@@ -163,7 +163,7 @@ void main() {
       expect(parameter.localIdentifier, equals('first.ptr'));
     });
 
-    test('projects IReference<BluetoothLEAdvertisementFlags>', () {
+    test('projects IReference<BluetoothLEAdvertisementFlags?>', () {
       final methodProjection = MethodProjection.fromTypeAndMethodName(
           'Windows.Devices.Bluetooth.Advertisement.IBluetoothLEAdvertisement',
           'put_Flags');
@@ -176,7 +176,7 @@ void main() {
           equals('value?.toReference().ptr.ref.lpVtbl ?? nullptr'));
     });
 
-    test('projects IReference<int>', () {
+    test('projects IReference<int?>', () {
       final methodProjection = MethodProjection.fromTypeAndMethodName(
           'Windows.Devices.Geolocation.IGeolocatorWithScalarAccuracy',
           'put_DesiredAccuracyInMeters');

--- a/packages/winrtgen/test/projections/setter_test.dart
+++ b/packages/winrtgen/test/projections/setter_test.dart
@@ -169,7 +169,7 @@ void main() {
           equals('set targetFile(IStorageFile? value)'));
     });
 
-    test('projects IReference<BluetoothLEAdvertisementFlags>', () {
+    test('projects IReference<BluetoothLEAdvertisementFlags?>', () {
       final projection = SetterProjection.fromTypeAndMethodName(
           'Windows.Devices.Bluetooth.Advertisement.IBluetoothLEAdvertisement',
           'put_Flags');

--- a/packages/winrtgen/test/utilities/extensions/type_identifier_helpers_test.dart
+++ b/packages/winrtgen/test/utilities/extensions/type_identifier_helpers_test.dart
@@ -361,7 +361,7 @@ void main() {
               .returnType
               .typeIdentifier
               .shortName,
-          equals('IAsyncOperation<IVectorView<StorageFile>>'));
+          equals('IAsyncOperation<IVectorView<StorageFile?>>'));
     });
 
     test('(10)', () {
@@ -405,7 +405,7 @@ void main() {
               .typeIdentifier
               .shortName,
           equals(
-              'AsyncOperationProgressHandler<IVectorView<ISmsMessage>, int>'));
+              'AsyncOperationProgressHandler<IVectorView<ISmsMessage?>, int>'));
     });
   });
 
@@ -531,20 +531,20 @@ void main() {
               'pinterface({e480ce40-a338-4ada-adcf-272272e48cb9};enum(Windows.Devices.Sensors.PedometerStepKind;i4);rc(Windows.Devices.Sensors.PedometerReading;{2245dcf4-a8e1-432f-896a-be0dd9b02d24}))'));
     });
 
-    // TODO: Enable this test when a new version of winmd is released.
-    // test(
-    //     'returns the signature of AsyncOperationProgressHandler<IVectorView<ISmsMessage>, int>',
-    //     () {
-    //   final typeDef = getMetadataForType(
-    //       'Windows.Devices.Sms.GetSmsMessagesOperation');
-    //   expect(
-    //       typeDef
-    //           .findMethod('get_Progress')!
-    //           .returnType
-    //           .typeIdentifier
-    //           .signature,
-    //       equals('pinterface()'));
-    // });
+    test(
+        'returns the signature of AsyncOperationProgressHandler<IVectorView<ISmsMessage>, int>',
+        () {
+      final typeDef =
+          getMetadataForType('Windows.Devices.Sms.GetSmsMessagesOperation');
+      expect(
+          typeDef
+              .findMethod('get_Progress')!
+              .returnType
+              .typeIdentifier
+              .signature,
+          equals(
+              'pinterface({c49b9bba-03ab-522e-884f-227352c8e7d1};pinterface({bbe1fa4c-b0e3-4583-baef-1f1b2e483e56};{ed3c5e28-6984-4b07-811d-8d5906ed3cea});i4)'));
+    });
   });
 
   group('typeArgs', () {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

When I initially added support for WinRT Vectors, I was unaware that it was possible for them to contain null elements. However, while working on #285, I discovered that they can indeed contain null elements.

This change only impacts type arguments such as `Uri` and subtypes of `IInspectable` (such as `StorageFile`), while other type arguments remain non-nullable.

## Related Issue

<!--- Link the relevant issue here -->

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🧪 `test` -- Test
- [ ] 🗑️ `chore` -- Chore
