### PR TITLE
fix!: parameters of type `Uri` and WinRT object are now nullable

### DIFF
--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelbinding.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelbinding.dart
@@ -49,7 +49,7 @@ class ILearningModelBinding extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  void bindWithProperties(String name, Object? value, IPropertySet props) {
+  void bindWithProperties(String name, Object? value, IPropertySet? props) {
     final nameHString = name.toHString();
 
     final hr = ptr.ref.vtable
@@ -66,7 +66,7 @@ class ILearningModelBinding extends IInspectable {
         ptr.ref.lpVtbl,
         nameHString,
         value?.intoBox().ptr.ref.lpVtbl ?? nullptr,
-        props.ptr.ref.lpVtbl);
+        props == null ? nullptr : props.ptr.ref.lpVtbl);
 
     WindowsDeleteString(nameHString);
 

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelbindingfactory.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelbindingfactory.dart
@@ -30,7 +30,7 @@ class ILearningModelBindingFactory extends IInspectable {
       ILearningModelBindingFactory.fromPtr(
           interface.toInterface(IID_ILearningModelBindingFactory));
 
-  LearningModelBinding createFromSession(LearningModelSession session) {
+  LearningModelBinding createFromSession(LearningModelSession? session) {
     final value = calloc<COMObject>();
 
     final hr =
@@ -46,8 +46,8 @@ class ILearningModelBindingFactory extends IInspectable {
                 .value
                 .asFunction<
                     int Function(VTablePointer lpVtbl, VTablePointer session,
-                        Pointer<COMObject> value)>()(
-            ptr.ref.lpVtbl, session.ptr.ref.lpVtbl, value);
+                        Pointer<COMObject> value)>()(ptr.ref.lpVtbl,
+            session == null ? nullptr : session.ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) {
       free(value);

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelsession.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelsession.dart
@@ -111,7 +111,7 @@ class ILearningModelSession extends IInspectable {
   }
 
   Future<LearningModelEvaluationResult?> evaluateAsync(
-      LearningModelBinding bindings, String correlationId) {
+      LearningModelBinding? bindings, String correlationId) {
     final operation = calloc<COMObject>();
     final correlationIdHString = correlationId.toHString();
 
@@ -130,7 +130,7 @@ class ILearningModelSession extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer bindings,
                     int correlationId, Pointer<COMObject> operation)>()(
         ptr.ref.lpVtbl,
-        bindings.ptr.ref.lpVtbl,
+        bindings == null ? nullptr : bindings.ptr.ref.lpVtbl,
         correlationIdHString,
         operation);
 
@@ -148,7 +148,7 @@ class ILearningModelSession extends IInspectable {
   }
 
   Future<LearningModelEvaluationResult?> evaluateFeaturesAsync(
-      IMap<String, Object?> features, String correlationId) {
+      IMap<String, Object?>? features, String correlationId) {
     final operation = calloc<COMObject>();
     final correlationIdHString = correlationId.toHString();
 
@@ -167,7 +167,7 @@ class ILearningModelSession extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer features,
                     int correlationId, Pointer<COMObject> operation)>()(
         ptr.ref.lpVtbl,
-        features.ptr.ref.lpVtbl,
+        features?.ptr.ref.lpVtbl ?? nullptr,
         correlationIdHString,
         operation);
 
@@ -185,7 +185,7 @@ class ILearningModelSession extends IInspectable {
   }
 
   LearningModelEvaluationResult? evaluate(
-      LearningModelBinding bindings, String correlationId) {
+      LearningModelBinding? bindings, String correlationId) {
     final result = calloc<COMObject>();
     final correlationIdHString = correlationId.toHString();
 
@@ -203,7 +203,10 @@ class ILearningModelSession extends IInspectable {
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer bindings,
                     int correlationId, Pointer<COMObject> result)>()(
-        ptr.ref.lpVtbl, bindings.ptr.ref.lpVtbl, correlationIdHString, result);
+        ptr.ref.lpVtbl,
+        bindings == null ? nullptr : bindings.ptr.ref.lpVtbl,
+        correlationIdHString,
+        result);
 
     WindowsDeleteString(correlationIdHString);
 
@@ -221,7 +224,7 @@ class ILearningModelSession extends IInspectable {
   }
 
   LearningModelEvaluationResult? evaluateFeatures(
-      IMap<String, Object?> features, String correlationId) {
+      IMap<String, Object?>? features, String correlationId) {
     final result = calloc<COMObject>();
     final correlationIdHString = correlationId.toHString();
 
@@ -239,7 +242,10 @@ class ILearningModelSession extends IInspectable {
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer features,
                     int correlationId, Pointer<COMObject> result)>()(
-        ptr.ref.lpVtbl, features.ptr.ref.lpVtbl, correlationIdHString, result);
+        ptr.ref.lpVtbl,
+        features?.ptr.ref.lpVtbl ?? nullptr,
+        correlationIdHString,
+        result);
 
     WindowsDeleteString(correlationIdHString);
 

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelsessionfactory.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelsessionfactory.dart
@@ -31,23 +31,21 @@ class ILearningModelSessionFactory extends IInspectable {
       ILearningModelSessionFactory.fromPtr(
           interface.toInterface(IID_ILearningModelSessionFactory));
 
-  LearningModelSession createFromModel(LearningModel model) {
+  LearningModelSession createFromModel(LearningModel? model) {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
-        .elementAt(6)
-        .cast<
-            Pointer<
-                NativeFunction<
-                    HRESULT Function(VTablePointer lpVtbl, VTablePointer model,
-                        Pointer<COMObject> value)>>>()
-        .value
-        .asFunction<
-            int Function(
-                VTablePointer lpVtbl,
-                VTablePointer model,
-                Pointer<COMObject>
-                    value)>()(ptr.ref.lpVtbl, model.ptr.ref.lpVtbl, value);
+            .elementAt(6)
+            .cast<
+                Pointer<
+                    NativeFunction<
+                        HRESULT Function(VTablePointer lpVtbl, VTablePointer model,
+                            Pointer<COMObject> value)>>>()
+            .value
+            .asFunction<
+                int Function(VTablePointer lpVtbl, VTablePointer model,
+                    Pointer<COMObject> value)>()(
+        ptr.ref.lpVtbl, model == null ? nullptr : model.ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) {
       free(value);
@@ -58,7 +56,7 @@ class ILearningModelSessionFactory extends IInspectable {
   }
 
   LearningModelSession createFromModelOnDevice(
-      LearningModel model, LearningModelDevice deviceToRunOn) {
+      LearningModel? model, LearningModelDevice? deviceToRunOn) {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -76,8 +74,8 @@ class ILearningModelSessionFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer model,
                     VTablePointer deviceToRunOn, Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        model.ptr.ref.lpVtbl,
-        deviceToRunOn.ptr.ref.lpVtbl,
+        model == null ? nullptr : model.ptr.ref.lpVtbl,
+        deviceToRunOn == null ? nullptr : deviceToRunOn.ptr.ref.lpVtbl,
         value);
 
     if (FAILED(hr)) {

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelsessionfactory2.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelsessionfactory2.dart
@@ -33,9 +33,9 @@ class ILearningModelSessionFactory2 extends IInspectable {
           interface.toInterface(IID_ILearningModelSessionFactory2));
 
   LearningModelSession createFromModelOnDeviceWithSessionOptions(
-      LearningModel model,
-      LearningModelDevice deviceToRunOn,
-      LearningModelSessionOptions learningModelSessionOptions) {
+      LearningModel? model,
+      LearningModelDevice? deviceToRunOn,
+      LearningModelSessionOptions? learningModelSessionOptions) {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -58,9 +58,11 @@ class ILearningModelSessionFactory2 extends IInspectable {
                     VTablePointer learningModelSessionOptions,
                     Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        model.ptr.ref.lpVtbl,
-        deviceToRunOn.ptr.ref.lpVtbl,
-        learningModelSessionOptions.ptr.ref.lpVtbl,
+        model == null ? nullptr : model.ptr.ref.lpVtbl,
+        deviceToRunOn == null ? nullptr : deviceToRunOn.ptr.ref.lpVtbl,
+        learningModelSessionOptions == null
+            ? nullptr
+            : learningModelSessionOptions.ptr.ref.lpVtbl,
         value);
 
     if (FAILED(hr)) {

--- a/packages/windows_ai/lib/src/machinelearning/learningmodelbinding.dart
+++ b/packages/windows_ai/lib/src/machinelearning/learningmodelbinding.dart
@@ -30,7 +30,7 @@ class LearningModelBinding extends IInspectable
   static const _className = 'Windows.AI.MachineLearning.LearningModelBinding';
 
   factory LearningModelBinding.createFromSession(
-          LearningModelSession session) =>
+          LearningModelSession? session) =>
       createActivationFactory(ILearningModelBindingFactory.fromPtr, _className,
               IID_ILearningModelBindingFactory)
           .createFromSession(session);
@@ -42,7 +42,7 @@ class LearningModelBinding extends IInspectable
       _iLearningModelBinding.bind(name, value);
 
   @override
-  void bindWithProperties(String name, Object? value, IPropertySet props) =>
+  void bindWithProperties(String name, Object? value, IPropertySet? props) =>
       _iLearningModelBinding.bindWithProperties(name, value, props);
 
   @override

--- a/packages/windows_ai/lib/src/machinelearning/learningmodelsession.dart
+++ b/packages/windows_ai/lib/src/machinelearning/learningmodelsession.dart
@@ -31,21 +31,21 @@ class LearningModelSession extends IInspectable
 
   static const _className = 'Windows.AI.MachineLearning.LearningModelSession';
 
-  factory LearningModelSession.createFromModel(LearningModel model) =>
+  factory LearningModelSession.createFromModel(LearningModel? model) =>
       createActivationFactory(ILearningModelSessionFactory.fromPtr, _className,
               IID_ILearningModelSessionFactory)
           .createFromModel(model);
 
   factory LearningModelSession.createFromModelOnDevice(
-          LearningModel model, LearningModelDevice deviceToRunOn) =>
+          LearningModel? model, LearningModelDevice? deviceToRunOn) =>
       createActivationFactory(ILearningModelSessionFactory.fromPtr, _className,
               IID_ILearningModelSessionFactory)
           .createFromModelOnDevice(model, deviceToRunOn);
 
   factory LearningModelSession.createFromModelOnDeviceWithSessionOptions(
-          LearningModel model,
-          LearningModelDevice deviceToRunOn,
-          LearningModelSessionOptions learningModelSessionOptions) =>
+          LearningModel? model,
+          LearningModelDevice? deviceToRunOn,
+          LearningModelSessionOptions? learningModelSessionOptions) =>
       createActivationFactory(ILearningModelSessionFactory2.fromPtr, _className,
               IID_ILearningModelSessionFactory2)
           .createFromModelOnDeviceWithSessionOptions(
@@ -65,22 +65,22 @@ class LearningModelSession extends IInspectable
 
   @override
   Future<LearningModelEvaluationResult?> evaluateAsync(
-          LearningModelBinding bindings, String correlationId) =>
+          LearningModelBinding? bindings, String correlationId) =>
       _iLearningModelSession.evaluateAsync(bindings, correlationId);
 
   @override
   Future<LearningModelEvaluationResult?> evaluateFeaturesAsync(
-          IMap<String, Object?> features, String correlationId) =>
+          IMap<String, Object?>? features, String correlationId) =>
       _iLearningModelSession.evaluateFeaturesAsync(features, correlationId);
 
   @override
   LearningModelEvaluationResult? evaluate(
-          LearningModelBinding bindings, String correlationId) =>
+          LearningModelBinding? bindings, String correlationId) =>
       _iLearningModelSession.evaluate(bindings, correlationId);
 
   @override
   LearningModelEvaluationResult? evaluateFeatures(
-          IMap<String, Object?> features, String correlationId) =>
+          IMap<String, Object?>? features, String correlationId) =>
       _iLearningModelSession.evaluateFeatures(features, correlationId);
 
   late final _iClosable = IClosable.from(this);

--- a/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
+++ b/packages/windows_data/lib/src/json/ijsonobjectwithdefaultvalues.dart
@@ -76,7 +76,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
     return JsonValue.fromPtr(returnValue);
   }
 
-  JsonObject getNamedObjectOrDefault(String name, JsonObject defaultValue) {
+  JsonObject getNamedObjectOrDefault(String name, JsonObject? defaultValue) {
     final returnValue = calloc<COMObject>();
     final nameHString = name.toHString();
 
@@ -97,7 +97,10 @@ class IJsonObjectWithDefaultValues extends IInspectable
                     int name,
                     VTablePointer defaultValue,
                     Pointer<COMObject> returnValue)>()(
-        ptr.ref.lpVtbl, nameHString, defaultValue.ptr.ref.lpVtbl, returnValue);
+        ptr.ref.lpVtbl,
+        nameHString,
+        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
+        returnValue);
 
     WindowsDeleteString(nameHString);
 
@@ -145,7 +148,7 @@ class IJsonObjectWithDefaultValues extends IInspectable
     }
   }
 
-  JsonArray getNamedArrayOrDefault(String name, JsonArray defaultValue) {
+  JsonArray getNamedArrayOrDefault(String name, JsonArray? defaultValue) {
     final returnValue = calloc<COMObject>();
     final nameHString = name.toHString();
 
@@ -166,7 +169,10 @@ class IJsonObjectWithDefaultValues extends IInspectable
                     int name,
                     VTablePointer defaultValue,
                     Pointer<COMObject> returnValue)>()(
-        ptr.ref.lpVtbl, nameHString, defaultValue.ptr.ref.lpVtbl, returnValue);
+        ptr.ref.lpVtbl,
+        nameHString,
+        defaultValue == null ? nullptr : defaultValue.ptr.ref.lpVtbl,
+        returnValue);
 
     WindowsDeleteString(nameHString);
 

--- a/packages/windows_data/lib/src/json/jsonobject.dart
+++ b/packages/windows_data/lib/src/json/jsonobject.dart
@@ -141,7 +141,7 @@ class JsonObject extends IInspectable
       _iJsonObjectWithDefaultValues.getNamedValueOrDefault(name, defaultValue);
 
   @override
-  JsonObject getNamedObjectOrDefault(String name, JsonObject defaultValue) =>
+  JsonObject getNamedObjectOrDefault(String name, JsonObject? defaultValue) =>
       _iJsonObjectWithDefaultValues.getNamedObjectOrDefault(name, defaultValue);
 
   @override
@@ -149,7 +149,7 @@ class JsonObject extends IInspectable
       _iJsonObjectWithDefaultValues.getNamedStringOrDefault(name, defaultValue);
 
   @override
-  JsonArray getNamedArrayOrDefault(String name, JsonArray defaultValue) =>
+  JsonArray getNamedArrayOrDefault(String name, JsonArray? defaultValue) =>
       _iJsonObjectWithDefaultValues.getNamedArrayOrDefault(name, defaultValue);
 
   @override

--- a/packages/windows_globalization/lib/src/calendar.dart
+++ b/packages/windows_globalization/lib/src/calendar.dart
@@ -30,18 +30,18 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
   static const _className = 'Windows.Globalization.Calendar';
 
   factory Calendar.createCalendarDefaultCalendarAndClock(
-          IIterable<String> languages) =>
+          IIterable<String>? languages) =>
       createActivationFactory(
               ICalendarFactory.fromPtr, _className, IID_ICalendarFactory)
           .createCalendarDefaultCalendarAndClock(languages);
 
   factory Calendar.createCalendar(
-          IIterable<String> languages, String calendar, String clock) =>
+          IIterable<String>? languages, String calendar, String clock) =>
       createActivationFactory(
               ICalendarFactory.fromPtr, _className, IID_ICalendarFactory)
           .createCalendar(languages, calendar, clock);
 
-  factory Calendar.createCalendarWithTimeZone(IIterable<String> languages,
+  factory Calendar.createCalendarWithTimeZone(IIterable<String>? languages,
           String calendar, String clock, String timeZoneId) =>
       createActivationFactory(
               ICalendarFactory2.fromPtr, _className, IID_ICalendarFactory2)

--- a/packages/windows_globalization/lib/src/datetimeformatting/datetimeformatter.dart
+++ b/packages/windows_globalization/lib/src/datetimeformatting/datetimeformatter.dart
@@ -41,14 +41,14 @@ class DateTimeFormatter extends IInspectable
           .createDateTimeFormatter(formatTemplate);
 
   factory DateTimeFormatter.createDateTimeFormatterLanguages(
-          String formatTemplate, IIterable<String> languages) =>
+          String formatTemplate, IIterable<String>? languages) =>
       createActivationFactory(IDateTimeFormatterFactory.fromPtr, _className,
               IID_IDateTimeFormatterFactory)
           .createDateTimeFormatterLanguages(formatTemplate, languages);
 
   factory DateTimeFormatter.createDateTimeFormatterContext(
           String formatTemplate,
-          IIterable<String> languages,
+          IIterable<String>? languages,
           String geographicRegion,
           String calendar,
           String clock) =>
@@ -81,7 +81,7 @@ class DateTimeFormatter extends IInspectable
           HourFormat hourFormat,
           MinuteFormat minuteFormat,
           SecondFormat secondFormat,
-          IIterable<String> languages) =>
+          IIterable<String>? languages) =>
       createActivationFactory(IDateTimeFormatterFactory.fromPtr, _className,
               IID_IDateTimeFormatterFactory)
           .createDateTimeFormatterDateTimeLanguages(
@@ -102,7 +102,7 @@ class DateTimeFormatter extends IInspectable
           HourFormat hourFormat,
           MinuteFormat minuteFormat,
           SecondFormat secondFormat,
-          IIterable<String> languages,
+          IIterable<String>? languages,
           String geographicRegion,
           String calendar,
           String clock) =>

--- a/packages/windows_globalization/lib/src/datetimeformatting/idatetimeformatterfactory.dart
+++ b/packages/windows_globalization/lib/src/datetimeformatting/idatetimeformatterfactory.dart
@@ -66,7 +66,7 @@ class IDateTimeFormatterFactory extends IInspectable {
   }
 
   DateTimeFormatter createDateTimeFormatterLanguages(
-      String formatTemplate, IIterable<String> languages) {
+      String formatTemplate, IIterable<String>? languages) {
     final result = calloc<COMObject>();
     final formatTemplateHString = formatTemplate.toHString();
 
@@ -86,11 +86,13 @@ class IDateTimeFormatterFactory extends IInspectable {
                     VTablePointer languages, Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
         formatTemplateHString,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         result);
 
     WindowsDeleteString(formatTemplateHString);
@@ -105,7 +107,7 @@ class IDateTimeFormatterFactory extends IInspectable {
 
   DateTimeFormatter createDateTimeFormatterContext(
       String formatTemplate,
-      IIterable<String> languages,
+      IIterable<String>? languages,
       String geographicRegion,
       String calendar,
       String clock) {
@@ -140,11 +142,13 @@ class IDateTimeFormatterFactory extends IInspectable {
                     Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
         formatTemplateHString,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         geographicRegionHString,
         calendarHString,
         clockHString,
@@ -247,7 +251,7 @@ class IDateTimeFormatterFactory extends IInspectable {
       HourFormat hourFormat,
       MinuteFormat minuteFormat,
       SecondFormat secondFormat,
-      IIterable<String> languages) {
+      IIterable<String>? languages) {
     final result = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -287,11 +291,13 @@ class IDateTimeFormatterFactory extends IInspectable {
         hourFormat.value,
         minuteFormat.value,
         secondFormat.value,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         result);
 
     if (FAILED(hr)) {
@@ -310,7 +316,7 @@ class IDateTimeFormatterFactory extends IInspectable {
       HourFormat hourFormat,
       MinuteFormat minuteFormat,
       SecondFormat secondFormat,
-      IIterable<String> languages,
+      IIterable<String>? languages,
       String geographicRegion,
       String calendar,
       String clock) {
@@ -362,11 +368,13 @@ class IDateTimeFormatterFactory extends IInspectable {
         hourFormat.value,
         minuteFormat.value,
         secondFormat.value,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         geographicRegionHString,
         calendarHString,
         clockHString,

--- a/packages/windows_globalization/lib/src/icalendarfactory.dart
+++ b/packages/windows_globalization/lib/src/icalendarfactory.dart
@@ -27,7 +27,7 @@ class ICalendarFactory extends IInspectable {
   factory ICalendarFactory.from(IInspectable interface) =>
       ICalendarFactory.fromPtr(interface.toInterface(IID_ICalendarFactory));
 
-  Calendar createCalendarDefaultCalendarAndClock(IIterable<String> languages) {
+  Calendar createCalendarDefaultCalendarAndClock(IIterable<String>? languages) {
     final result = calloc<COMObject>();
 
     final hr =
@@ -43,14 +43,20 @@ class ICalendarFactory extends IInspectable {
                                 Pointer<COMObject> result)>>>()
                 .value
                 .asFunction<
-                    int Function(VTablePointer lpVtbl, VTablePointer languages,
-                        Pointer<COMObject> result)>()(
+                    int Function(
+                        VTablePointer lpVtbl,
+                        VTablePointer languages,
+                        Pointer<COMObject>
+                            result)>()(
             ptr.ref.lpVtbl,
-            IInspectable(languages
-                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-                .ptr
-                .ref
-                .lpVtbl,
+            languages ==
+                    null
+                ? nullptr
+                : IInspectable(languages
+                        .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                    .ptr
+                    .ref
+                    .lpVtbl,
             result);
 
     if (FAILED(hr)) {
@@ -62,7 +68,7 @@ class ICalendarFactory extends IInspectable {
   }
 
   Calendar createCalendar(
-      IIterable<String> languages, String calendar, String clock) {
+      IIterable<String>? languages, String calendar, String clock) {
     final result = calloc<COMObject>();
     final calendarHString = calendar.toHString();
     final clockHString = clock.toHString();
@@ -83,11 +89,13 @@ class ICalendarFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer languages,
                     int calendar, int clock, Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         calendarHString,
         clockHString,
         result);

--- a/packages/windows_globalization/lib/src/icalendarfactory2.dart
+++ b/packages/windows_globalization/lib/src/icalendarfactory2.dart
@@ -27,7 +27,7 @@ class ICalendarFactory2 extends IInspectable {
   factory ICalendarFactory2.from(IInspectable interface) =>
       ICalendarFactory2.fromPtr(interface.toInterface(IID_ICalendarFactory2));
 
-  Calendar createCalendarWithTimeZone(IIterable<String> languages,
+  Calendar createCalendarWithTimeZone(IIterable<String>? languages,
       String calendar, String clock, String timeZoneId) {
     final result = calloc<COMObject>();
     final calendarHString = calendar.toHString();
@@ -56,11 +56,13 @@ class ICalendarFactory2 extends IInspectable {
                     int timeZoneId,
                     Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         calendarHString,
         clockHString,
         timeZoneIdHString,

--- a/packages/windows_globalization/lib/src/numberformatting/currencyformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/currencyformatter.dart
@@ -51,7 +51,7 @@ class CurrencyFormatter extends IInspectable
 
   factory CurrencyFormatter.createCurrencyFormatterCodeContext(
           String currencyCode,
-          IIterable<String> languages,
+          IIterable<String>? languages,
           String geographicRegion) =>
       createActivationFactory(ICurrencyFormatterFactory.fromPtr, _className,
               IID_ICurrencyFormatterFactory)

--- a/packages/windows_globalization/lib/src/numberformatting/decimalformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/decimalformatter.dart
@@ -40,7 +40,7 @@ class DecimalFormatter extends IInspectable
       'Windows.Globalization.NumberFormatting.DecimalFormatter';
 
   factory DecimalFormatter.createDecimalFormatter(
-          IIterable<String> languages, String geographicRegion) =>
+          IIterable<String>? languages, String geographicRegion) =>
       createActivationFactory(IDecimalFormatterFactory.fromPtr, _className,
               IID_IDecimalFormatterFactory)
           .createDecimalFormatter(languages, geographicRegion);

--- a/packages/windows_globalization/lib/src/numberformatting/icurrencyformatterfactory.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/icurrencyformatterfactory.dart
@@ -58,7 +58,7 @@ class ICurrencyFormatterFactory extends IInspectable {
   }
 
   CurrencyFormatter createCurrencyFormatterCodeContext(String currencyCode,
-      IIterable<String> languages, String geographicRegion) {
+      IIterable<String>? languages, String geographicRegion) {
     final result = calloc<COMObject>();
     final currencyCodeHString = currencyCode.toHString();
     final geographicRegionHString = geographicRegion.toHString();
@@ -84,11 +84,13 @@ class ICurrencyFormatterFactory extends IInspectable {
                     Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
         currencyCodeHString,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         geographicRegionHString,
         result);
 

--- a/packages/windows_globalization/lib/src/numberformatting/idecimalformatterfactory.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/idecimalformatterfactory.dart
@@ -29,7 +29,7 @@ class IDecimalFormatterFactory extends IInspectable {
           interface.toInterface(IID_IDecimalFormatterFactory));
 
   DecimalFormatter createDecimalFormatter(
-      IIterable<String> languages, String geographicRegion) {
+      IIterable<String>? languages, String geographicRegion) {
     final result = calloc<COMObject>();
     final geographicRegionHString = geographicRegion.toHString();
 
@@ -48,11 +48,13 @@ class IDecimalFormatterFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer languages,
                     int geographicRegion, Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         geographicRegionHString,
         result);
 

--- a/packages/windows_globalization/lib/src/numberformatting/inumeralsystemtranslatorfactory.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/inumeralsystemtranslatorfactory.dart
@@ -29,7 +29,7 @@ class INumeralSystemTranslatorFactory extends IInspectable {
       INumeralSystemTranslatorFactory.fromPtr(
           interface.toInterface(IID_INumeralSystemTranslatorFactory));
 
-  NumeralSystemTranslator create(IIterable<String> languages) {
+  NumeralSystemTranslator create(IIterable<String>? languages) {
     final result = calloc<COMObject>();
 
     final hr =
@@ -45,14 +45,20 @@ class INumeralSystemTranslatorFactory extends IInspectable {
                                 Pointer<COMObject> result)>>>()
                 .value
                 .asFunction<
-                    int Function(VTablePointer lpVtbl, VTablePointer languages,
-                        Pointer<COMObject> result)>()(
+                    int Function(
+                        VTablePointer lpVtbl,
+                        VTablePointer languages,
+                        Pointer<COMObject>
+                            result)>()(
             ptr.ref.lpVtbl,
-            IInspectable(languages
-                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-                .ptr
-                .ref
-                .lpVtbl,
+            languages ==
+                    null
+                ? nullptr
+                : IInspectable(languages
+                        .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                    .ptr
+                    .ref
+                    .lpVtbl,
             result);
 
     if (FAILED(hr)) {

--- a/packages/windows_globalization/lib/src/numberformatting/ipercentformatterfactory.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/ipercentformatterfactory.dart
@@ -29,7 +29,7 @@ class IPercentFormatterFactory extends IInspectable {
           interface.toInterface(IID_IPercentFormatterFactory));
 
   PercentFormatter createPercentFormatter(
-      IIterable<String> languages, String geographicRegion) {
+      IIterable<String>? languages, String geographicRegion) {
     final result = calloc<COMObject>();
     final geographicRegionHString = geographicRegion.toHString();
 
@@ -48,11 +48,13 @@ class IPercentFormatterFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer languages,
                     int geographicRegion, Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         geographicRegionHString,
         result);
 

--- a/packages/windows_globalization/lib/src/numberformatting/ipermilleformatterfactory.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/ipermilleformatterfactory.dart
@@ -29,7 +29,7 @@ class IPermilleFormatterFactory extends IInspectable {
           interface.toInterface(IID_IPermilleFormatterFactory));
 
   PermilleFormatter createPermilleFormatter(
-      IIterable<String> languages, String geographicRegion) {
+      IIterable<String>? languages, String geographicRegion) {
     final result = calloc<COMObject>();
     final geographicRegionHString = geographicRegion.toHString();
 
@@ -48,11 +48,13 @@ class IPermilleFormatterFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer languages,
                     int geographicRegion, Pointer<COMObject> result)>()(
         ptr.ref.lpVtbl,
-        IInspectable(
-                languages.toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        languages == null
+            ? nullptr
+            : IInspectable(languages
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         geographicRegionHString,
         result);
 

--- a/packages/windows_globalization/lib/src/numberformatting/numeralsystemtranslator.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/numeralsystemtranslator.dart
@@ -28,7 +28,7 @@ class NumeralSystemTranslator extends IInspectable
   static const _className =
       'Windows.Globalization.NumberFormatting.NumeralSystemTranslator';
 
-  factory NumeralSystemTranslator.create(IIterable<String> languages) =>
+  factory NumeralSystemTranslator.create(IIterable<String>? languages) =>
       createActivationFactory(INumeralSystemTranslatorFactory.fromPtr,
               _className, IID_INumeralSystemTranslatorFactory)
           .create(languages);

--- a/packages/windows_globalization/lib/src/numberformatting/percentformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/percentformatter.dart
@@ -40,7 +40,7 @@ class PercentFormatter extends IInspectable
       'Windows.Globalization.NumberFormatting.PercentFormatter';
 
   factory PercentFormatter.createPercentFormatter(
-          IIterable<String> languages, String geographicRegion) =>
+          IIterable<String>? languages, String geographicRegion) =>
       createActivationFactory(IPercentFormatterFactory.fromPtr, _className,
               IID_IPercentFormatterFactory)
           .createPercentFormatter(languages, geographicRegion);

--- a/packages/windows_globalization/lib/src/numberformatting/permilleformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/permilleformatter.dart
@@ -40,7 +40,7 @@ class PermilleFormatter extends IInspectable
       'Windows.Globalization.NumberFormatting.PermilleFormatter';
 
   factory PermilleFormatter.createPermilleFormatter(
-          IIterable<String> languages, String geographicRegion) =>
+          IIterable<String>? languages, String geographicRegion) =>
       createActivationFactory(IPermilleFormatterFactory.fromPtr, _className,
               IID_IPermilleFormatterFactory)
           .createPermilleFormatter(languages, geographicRegion);

--- a/packages/windows_networking/lib/src/endpointpair.dart
+++ b/packages/windows_networking/lib/src/endpointpair.dart
@@ -27,9 +27,9 @@ class EndpointPair extends IInspectable implements IEndpointPair {
   static const _className = 'Windows.Networking.EndpointPair';
 
   factory EndpointPair.createEndpointPair(
-          HostName localHostName,
+          HostName? localHostName,
           String localServiceName,
-          HostName remoteHostName,
+          HostName? remoteHostName,
           String remoteServiceName) =>
       createActivationFactory(IEndpointPairFactory.fromPtr, _className,
               IID_IEndpointPairFactory)

--- a/packages/windows_networking/lib/src/iendpointpairfactory.dart
+++ b/packages/windows_networking/lib/src/iendpointpairfactory.dart
@@ -30,9 +30,9 @@ class IEndpointPairFactory extends IInspectable {
           interface.toInterface(IID_IEndpointPairFactory));
 
   EndpointPair createEndpointPair(
-      HostName localHostName,
+      HostName? localHostName,
       String localServiceName,
-      HostName remoteHostName,
+      HostName? remoteHostName,
       String remoteServiceName) {
     final value = calloc<COMObject>();
     final localServiceNameHString = localServiceName.toHString();
@@ -60,9 +60,9 @@ class IEndpointPairFactory extends IInspectable {
                     int remoteServiceName,
                     Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        localHostName.ptr.ref.lpVtbl,
+        localHostName == null ? nullptr : localHostName.ptr.ref.lpVtbl,
         localServiceNameHString,
-        remoteHostName.ptr.ref.lpVtbl,
+        remoteHostName == null ? nullptr : remoteHostName.ptr.ref.lpVtbl,
         remoteServiceNameHString,
         value);
 

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequestfactory.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequestfactory.dart
@@ -31,7 +31,7 @@ class IWebTokenRequestFactory extends IInspectable {
           interface.toInterface(IID_IWebTokenRequestFactory));
 
   WebTokenRequest create(
-      WebAccountProvider provider, String scope, String clientId) {
+      WebAccountProvider? provider, String scope, String clientId) {
     final webTokenRequest = calloc<COMObject>();
     final scopeHString = scope.toHString();
     final clientIdHString = clientId.toHString();
@@ -56,7 +56,7 @@ class IWebTokenRequestFactory extends IInspectable {
                     int clientId,
                     Pointer<COMObject> webTokenRequest)>()(
         ptr.ref.lpVtbl,
-        provider.ptr.ref.lpVtbl,
+        provider == null ? nullptr : provider.ptr.ref.lpVtbl,
         scopeHString,
         clientIdHString,
         webTokenRequest);
@@ -72,7 +72,7 @@ class IWebTokenRequestFactory extends IInspectable {
     return WebTokenRequest.fromPtr(webTokenRequest);
   }
 
-  WebTokenRequest createWithPromptType(WebAccountProvider provider,
+  WebTokenRequest createWithPromptType(WebAccountProvider? provider,
       String scope, String clientId, WebTokenRequestPromptType promptType) {
     final webTokenRequest = calloc<COMObject>();
     final scopeHString = scope.toHString();
@@ -100,7 +100,7 @@ class IWebTokenRequestFactory extends IInspectable {
                     int promptType,
                     Pointer<COMObject> webTokenRequest)>()(
         ptr.ref.lpVtbl,
-        provider.ptr.ref.lpVtbl,
+        provider == null ? nullptr : provider.ptr.ref.lpVtbl,
         scopeHString,
         clientIdHString,
         promptType.value,
@@ -117,7 +117,7 @@ class IWebTokenRequestFactory extends IInspectable {
     return WebTokenRequest.fromPtr(webTokenRequest);
   }
 
-  WebTokenRequest createWithProvider(WebAccountProvider provider) {
+  WebTokenRequest createWithProvider(WebAccountProvider? provider) {
     final webTokenRequest = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -132,8 +132,8 @@ class IWebTokenRequestFactory extends IInspectable {
             .value
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer provider,
-                    Pointer<COMObject> webTokenRequest)>()(
-        ptr.ref.lpVtbl, provider.ptr.ref.lpVtbl, webTokenRequest);
+                    Pointer<COMObject> webTokenRequest)>()(ptr.ref.lpVtbl,
+        provider == null ? nullptr : provider.ptr.ref.lpVtbl, webTokenRequest);
 
     if (FAILED(hr)) {
       free(webTokenRequest);
@@ -143,7 +143,7 @@ class IWebTokenRequestFactory extends IInspectable {
     return WebTokenRequest.fromPtr(webTokenRequest);
   }
 
-  WebTokenRequest createWithScope(WebAccountProvider provider, String scope) {
+  WebTokenRequest createWithScope(WebAccountProvider? provider, String scope) {
     final webTokenRequest = calloc<COMObject>();
     final scopeHString = scope.toHString();
 
@@ -161,7 +161,10 @@ class IWebTokenRequestFactory extends IInspectable {
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer provider,
                     int scope, Pointer<COMObject> webTokenRequest)>()(
-        ptr.ref.lpVtbl, provider.ptr.ref.lpVtbl, scopeHString, webTokenRequest);
+        ptr.ref.lpVtbl,
+        provider == null ? nullptr : provider.ptr.ref.lpVtbl,
+        scopeHString,
+        webTokenRequest);
 
     WindowsDeleteString(scopeHString);
 

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenresponsefactory.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenresponsefactory.dart
@@ -58,7 +58,7 @@ class IWebTokenResponseFactory extends IInspectable {
   }
 
   WebTokenResponse createWithTokenAndAccount(
-      String token, WebAccount webAccount) {
+      String token, WebAccount? webAccount) {
     final webTokenResponse = calloc<COMObject>();
     final tokenHString = token.toHString();
 
@@ -78,8 +78,11 @@ class IWebTokenResponseFactory extends IInspectable {
                     VTablePointer lpVtbl,
                     int token,
                     VTablePointer webAccount,
-                    Pointer<COMObject> webTokenResponse)>()(ptr.ref.lpVtbl,
-        tokenHString, webAccount.ptr.ref.lpVtbl, webTokenResponse);
+                    Pointer<COMObject> webTokenResponse)>()(
+        ptr.ref.lpVtbl,
+        tokenHString,
+        webAccount == null ? nullptr : webAccount.ptr.ref.lpVtbl,
+        webTokenResponse);
 
     WindowsDeleteString(tokenHString);
 
@@ -92,7 +95,7 @@ class IWebTokenResponseFactory extends IInspectable {
   }
 
   WebTokenResponse createWithTokenAccountAndError(
-      String token, WebAccount webAccount, WebProviderError error) {
+      String token, WebAccount? webAccount, WebProviderError? error) {
     final webTokenResponse = calloc<COMObject>();
     final tokenHString = token.toHString();
 
@@ -117,8 +120,8 @@ class IWebTokenResponseFactory extends IInspectable {
                     Pointer<COMObject> webTokenResponse)>()(
         ptr.ref.lpVtbl,
         tokenHString,
-        webAccount.ptr.ref.lpVtbl,
-        error.ptr.ref.lpVtbl,
+        webAccount == null ? nullptr : webAccount.ptr.ref.lpVtbl,
+        error == null ? nullptr : error.ptr.ref.lpVtbl,
         webTokenResponse);
 
     WindowsDeleteString(tokenHString);

--- a/packages/windows_security/lib/src/authentication/web/core/webtokenrequest.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webtokenrequest.dart
@@ -32,13 +32,13 @@ class WebTokenRequest extends IInspectable
       'Windows.Security.Authentication.Web.Core.WebTokenRequest';
 
   factory WebTokenRequest.create(
-          WebAccountProvider provider, String scope, String clientId) =>
+          WebAccountProvider? provider, String scope, String clientId) =>
       createActivationFactory(IWebTokenRequestFactory.fromPtr, _className,
               IID_IWebTokenRequestFactory)
           .create(provider, scope, clientId);
 
   factory WebTokenRequest.createWithPromptType(
-          WebAccountProvider provider,
+          WebAccountProvider? provider,
           String scope,
           String clientId,
           WebTokenRequestPromptType promptType) =>
@@ -46,13 +46,13 @@ class WebTokenRequest extends IInspectable
               IID_IWebTokenRequestFactory)
           .createWithPromptType(provider, scope, clientId, promptType);
 
-  factory WebTokenRequest.createWithProvider(WebAccountProvider provider) =>
+  factory WebTokenRequest.createWithProvider(WebAccountProvider? provider) =>
       createActivationFactory(IWebTokenRequestFactory.fromPtr, _className,
               IID_IWebTokenRequestFactory)
           .createWithProvider(provider);
 
   factory WebTokenRequest.createWithScope(
-          WebAccountProvider provider, String scope) =>
+          WebAccountProvider? provider, String scope) =>
       createActivationFactory(IWebTokenRequestFactory.fromPtr, _className,
               IID_IWebTokenRequestFactory)
           .createWithScope(provider, scope);

--- a/packages/windows_security/lib/src/authentication/web/core/webtokenresponse.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webtokenresponse.dart
@@ -35,13 +35,13 @@ class WebTokenResponse extends IInspectable implements IWebTokenResponse {
           .createWithToken(token);
 
   factory WebTokenResponse.createWithTokenAndAccount(
-          String token, WebAccount webAccount) =>
+          String token, WebAccount? webAccount) =>
       createActivationFactory(IWebTokenResponseFactory.fromPtr, _className,
               IID_IWebTokenResponseFactory)
           .createWithTokenAndAccount(token, webAccount);
 
   factory WebTokenResponse.createWithTokenAccountAndError(
-          String token, WebAccount webAccount, WebProviderError error) =>
+          String token, WebAccount? webAccount, WebProviderError? error) =>
       createActivationFactory(IWebTokenResponseFactory.fromPtr, _className,
               IID_IWebTokenResponseFactory)
           .createWithTokenAccountAndError(token, webAccount, error);

--- a/packages/windows_security/lib/src/credentials/iwebaccountfactory.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountfactory.dart
@@ -29,7 +29,7 @@ class IWebAccountFactory extends IInspectable {
   factory IWebAccountFactory.from(IInspectable interface) =>
       IWebAccountFactory.fromPtr(interface.toInterface(IID_IWebAccountFactory));
 
-  WebAccount createWebAccount(WebAccountProvider webAccountProvider,
+  WebAccount createWebAccount(WebAccountProvider? webAccountProvider,
       String userName, WebAccountState state) {
     final instance = calloc<COMObject>();
     final userNameHString = userName.toHString();
@@ -54,7 +54,9 @@ class IWebAccountFactory extends IInspectable {
                     int state,
                     Pointer<COMObject> instance)>()(
         ptr.ref.lpVtbl,
-        webAccountProvider.ptr.ref.lpVtbl,
+        webAccountProvider == null
+            ? nullptr
+            : webAccountProvider.ptr.ref.lpVtbl,
         userNameHString,
         state.value,
         instance);

--- a/packages/windows_security/lib/src/credentials/iwebaccountproviderfactory.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccountproviderfactory.dart
@@ -29,7 +29,7 @@ class IWebAccountProviderFactory extends IInspectable {
           interface.toInterface(IID_IWebAccountProviderFactory));
 
   WebAccountProvider createWebAccountProvider(
-      String id, String displayName, Uri iconUri) {
+      String id, String displayName, Uri? iconUri) {
     final instance = calloc<COMObject>();
     final idHString = id.toHString();
     final displayNameHString = displayName.toHString();
@@ -52,7 +52,7 @@ class IWebAccountProviderFactory extends IInspectable {
         ptr.ref.lpVtbl,
         idHString,
         displayNameHString,
-        iconUri.toWinRTUri().ptr.ref.lpVtbl,
+        iconUri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr,
         instance);
 
     WindowsDeleteString(idHString);

--- a/packages/windows_security/lib/src/credentials/webaccount.dart
+++ b/packages/windows_security/lib/src/credentials/webaccount.dart
@@ -29,7 +29,7 @@ class WebAccount extends IInspectable implements IWebAccount, IWebAccount2 {
 
   static const _className = 'Windows.Security.Credentials.WebAccount';
 
-  factory WebAccount.createWebAccount(WebAccountProvider webAccountProvider,
+  factory WebAccount.createWebAccount(WebAccountProvider? webAccountProvider,
           String userName, WebAccountState state) =>
       createActivationFactory(
               IWebAccountFactory.fromPtr, _className, IID_IWebAccountFactory)

--- a/packages/windows_security/lib/src/credentials/webaccountprovider.dart
+++ b/packages/windows_security/lib/src/credentials/webaccountprovider.dart
@@ -34,7 +34,7 @@ class WebAccountProvider extends IInspectable
   static const _className = 'Windows.Security.Credentials.WebAccountProvider';
 
   factory WebAccountProvider.createWebAccountProvider(
-          String id, String displayName, Uri iconUri) =>
+          String id, String displayName, Uri? iconUri) =>
       createActivationFactory(IWebAccountProviderFactory.fromPtr, _className,
               IID_IWebAccountProviderFactory)
           .createWebAccountProvider(id, displayName, iconUri);

--- a/packages/windows_storage/lib/src/search/iqueryoptionsfactory.dart
+++ b/packages/windows_storage/lib/src/search/iqueryoptionsfactory.dart
@@ -31,7 +31,7 @@ class IQueryOptionsFactory extends IInspectable {
           interface.toInterface(IID_IQueryOptionsFactory));
 
   QueryOptions createCommonFileQuery(
-      CommonFileQuery query, IIterable<String> fileTypeFilter) {
+      CommonFileQuery query, IIterable<String>? fileTypeFilter) {
     final queryOptions = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -53,11 +53,13 @@ class IQueryOptionsFactory extends IInspectable {
                     Pointer<COMObject> queryOptions)>()(
         ptr.ref.lpVtbl,
         query.value,
-        IInspectable(fileTypeFilter
-                .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        fileTypeFilter == null
+            ? nullptr
+            : IInspectable(fileTypeFilter
+                    .toInterface('{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}'))
+                .ptr
+                .ref
+                .lpVtbl,
         queryOptions);
 
     if (FAILED(hr)) {

--- a/packages/windows_storage/lib/src/search/queryoptions.dart
+++ b/packages/windows_storage/lib/src/search/queryoptions.dart
@@ -38,7 +38,7 @@ class QueryOptions extends IInspectable
   static const _className = 'Windows.Storage.Search.QueryOptions';
 
   factory QueryOptions.createCommonFileQuery(
-          CommonFileQuery query, IIterable<String> fileTypeFilter) =>
+          CommonFileQuery query, IIterable<String>? fileTypeFilter) =>
       createActivationFactory(IQueryOptionsFactory.fromPtr, _className,
               IID_IQueryOptionsFactory)
           .createCommonFileQuery(query, fileTypeFilter);

--- a/packages/windows_storage/lib/src/streams/datareader.dart
+++ b/packages/windows_storage/lib/src/streams/datareader.dart
@@ -31,7 +31,7 @@ class DataReader extends IInspectable implements IDataReader, IClosable {
 
   static const _className = 'Windows.Storage.Streams.DataReader';
 
-  factory DataReader.createDataReader(IInputStream inputStream) =>
+  factory DataReader.createDataReader(IInputStream? inputStream) =>
       createActivationFactory(
               IDataReaderFactory.fromPtr, _className, IID_IDataReaderFactory)
           .createDataReader(inputStream);

--- a/packages/windows_storage/lib/src/streams/datawriter.dart
+++ b/packages/windows_storage/lib/src/streams/datawriter.dart
@@ -30,7 +30,7 @@ class DataWriter extends IInspectable implements IDataWriter, IClosable {
 
   static const _className = 'Windows.Storage.Streams.DataWriter';
 
-  factory DataWriter.createDataWriter(IOutputStream outputStream) =>
+  factory DataWriter.createDataWriter(IOutputStream? outputStream) =>
       createActivationFactory(
               IDataWriterFactory.fromPtr, _className, IID_IDataWriterFactory)
           .createDataWriter(outputStream);

--- a/packages/windows_storage/lib/src/streams/idatareaderfactory.dart
+++ b/packages/windows_storage/lib/src/streams/idatareaderfactory.dart
@@ -28,7 +28,7 @@ class IDataReaderFactory extends IInspectable {
   factory IDataReaderFactory.from(IInspectable interface) =>
       IDataReaderFactory.fromPtr(interface.toInterface(IID_IDataReaderFactory));
 
-  DataReader createDataReader(IInputStream inputStream) {
+  DataReader createDataReader(IInputStream? inputStream) {
     final dataReader = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -43,8 +43,8 @@ class IDataReaderFactory extends IInspectable {
             .value
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer inputStream,
-                    Pointer<COMObject> dataReader)>()(
-        ptr.ref.lpVtbl, inputStream.ptr.ref.lpVtbl, dataReader);
+                    Pointer<COMObject> dataReader)>()(ptr.ref.lpVtbl,
+        inputStream == null ? nullptr : inputStream.ptr.ref.lpVtbl, dataReader);
 
     if (FAILED(hr)) {
       free(dataReader);

--- a/packages/windows_storage/lib/src/streams/idatawriterfactory.dart
+++ b/packages/windows_storage/lib/src/streams/idatawriterfactory.dart
@@ -28,7 +28,7 @@ class IDataWriterFactory extends IInspectable {
   factory IDataWriterFactory.from(IInspectable interface) =>
       IDataWriterFactory.fromPtr(interface.toInterface(IID_IDataWriterFactory));
 
-  DataWriter createDataWriter(IOutputStream outputStream) {
+  DataWriter createDataWriter(IOutputStream? outputStream) {
     final dataWriter = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -44,7 +44,9 @@ class IDataWriterFactory extends IInspectable {
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer outputStream,
                     Pointer<COMObject> dataWriter)>()(
-        ptr.ref.lpVtbl, outputStream.ptr.ref.lpVtbl, dataWriter);
+        ptr.ref.lpVtbl,
+        outputStream == null ? nullptr : outputStream.ptr.ref.lpVtbl,
+        dataWriter);
 
     if (FAILED(hr)) {
       free(dataWriter);

--- a/packages/windows_storage/lib/src/streams/ipropertysetserializer.dart
+++ b/packages/windows_storage/lib/src/streams/ipropertysetserializer.dart
@@ -30,7 +30,7 @@ class IPropertySetSerializer extends IInspectable {
       IPropertySetSerializer.fromPtr(
           interface.toInterface(IID_IPropertySetSerializer));
 
-  IBuffer? serialize(IPropertySet propertySet) {
+  IBuffer? serialize(IPropertySet? propertySet) {
     final result = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -45,8 +45,8 @@ class IPropertySetSerializer extends IInspectable {
             .value
             .asFunction<
                 int Function(VTablePointer lpVtbl, VTablePointer propertySet,
-                    Pointer<COMObject> result)>()(
-        ptr.ref.lpVtbl, propertySet.ptr.ref.lpVtbl, result);
+                    Pointer<COMObject> result)>()(ptr.ref.lpVtbl,
+        propertySet == null ? nullptr : propertySet.ptr.ref.lpVtbl, result);
 
     if (FAILED(hr)) {
       free(result);
@@ -61,7 +61,7 @@ class IPropertySetSerializer extends IInspectable {
     return IBuffer.fromPtr(result);
   }
 
-  void deserialize(IPropertySet propertySet, IBuffer? buffer) {
+  void deserialize(IPropertySet? propertySet, IBuffer? buffer) {
     final hr =
         ptr.ref.vtable
                 .elementAt(7)
@@ -77,7 +77,7 @@ class IPropertySetSerializer extends IInspectable {
                     int Function(VTablePointer lpVtbl,
                         VTablePointer propertySet, VTablePointer buffer)>()(
             ptr.ref.lpVtbl,
-            propertySet.ptr.ref.lpVtbl,
+            propertySet == null ? nullptr : propertySet.ptr.ref.lpVtbl,
             buffer == null ? nullptr : buffer.ptr.ref.lpVtbl);
 
     if (FAILED(hr)) throwWindowsException(hr);

--- a/packages/windows_system/lib/src/ilauncherstatics2.dart
+++ b/packages/windows_system/lib/src/ilauncherstatics2.dart
@@ -66,7 +66,7 @@ class ILauncherStatics2 extends IInspectable {
   }
 
   Future<LaunchUriResult?> launchUriForResultsWithDataAsync(
-      Uri? uri, LauncherOptions? options, ValueSet inputData) {
+      Uri? uri, LauncherOptions? options, ValueSet? inputData) {
     final operation = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -91,7 +91,7 @@ class ILauncherStatics2 extends IInspectable {
         ptr.ref.lpVtbl,
         uri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr,
         options == null ? nullptr : options.ptr.ref.lpVtbl,
-        inputData.ptr.ref.lpVtbl,
+        inputData == null ? nullptr : inputData.ptr.ref.lpVtbl,
         operation);
 
     if (FAILED(hr)) {
@@ -105,7 +105,7 @@ class ILauncherStatics2 extends IInspectable {
   }
 
   Future<bool> launchUriWithDataAsync(
-      Uri? uri, LauncherOptions? options, ValueSet inputData) {
+      Uri? uri, LauncherOptions? options, ValueSet? inputData) {
     final operation = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -130,7 +130,7 @@ class ILauncherStatics2 extends IInspectable {
         ptr.ref.lpVtbl,
         uri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr,
         options == null ? nullptr : options.ptr.ref.lpVtbl,
-        inputData.ptr.ref.lpVtbl,
+        inputData == null ? nullptr : inputData.ptr.ref.lpVtbl,
         operation);
 
     if (FAILED(hr)) {

--- a/packages/windows_system/lib/src/ilauncherstatics4.dart
+++ b/packages/windows_system/lib/src/ilauncherstatics4.dart
@@ -204,7 +204,7 @@ class ILauncherStatics4 extends IInspectable {
   }
 
   Future<LaunchUriStatus> launchUriWithDataForUserAsync(
-      User? user, Uri? uri, LauncherOptions? options, ValueSet inputData) {
+      User? user, Uri? uri, LauncherOptions? options, ValueSet? inputData) {
     final operation = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -232,7 +232,7 @@ class ILauncherStatics4 extends IInspectable {
         user == null ? nullptr : user.ptr.ref.lpVtbl,
         uri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr,
         options == null ? nullptr : options.ptr.ref.lpVtbl,
-        inputData.ptr.ref.lpVtbl,
+        inputData == null ? nullptr : inputData.ptr.ref.lpVtbl,
         operation);
 
     if (FAILED(hr)) {
@@ -285,7 +285,7 @@ class ILauncherStatics4 extends IInspectable {
   }
 
   Future<LaunchUriResult?> launchUriForResultsWithDataForUserAsync(
-      User? user, Uri? uri, LauncherOptions? options, ValueSet inputData) {
+      User? user, Uri? uri, LauncherOptions? options, ValueSet? inputData) {
     final operation = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -313,7 +313,7 @@ class ILauncherStatics4 extends IInspectable {
         user == null ? nullptr : user.ptr.ref.lpVtbl,
         uri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr,
         options == null ? nullptr : options.ptr.ref.lpVtbl,
-        inputData.ptr.ref.lpVtbl,
+        inputData == null ? nullptr : inputData.ptr.ref.lpVtbl,
         operation);
 
     if (FAILED(hr)) {

--- a/packages/windows_system/lib/src/iuser.dart
+++ b/packages/windows_system/lib/src/iuser.dart
@@ -131,7 +131,7 @@ class IUser extends IInspectable {
     return asyncOperation.toFuture(asyncOperation.getResults);
   }
 
-  Future<IPropertySet> getPropertiesAsync(IVectorView<String> values) {
+  Future<IPropertySet> getPropertiesAsync(IVectorView<String>? values) {
     final operation = calloc<COMObject>();
 
     final hr =
@@ -148,7 +148,7 @@ class IUser extends IInspectable {
                 .asFunction<
                     int Function(VTablePointer lpVtbl, VTablePointer values,
                         Pointer<COMObject> operation)>()(
-            ptr.ref.lpVtbl, values.ptr.ref.lpVtbl, operation);
+            ptr.ref.lpVtbl, values?.ptr.ref.lpVtbl ?? nullptr, operation);
 
     if (FAILED(hr)) {
       free(operation);

--- a/packages/windows_system/lib/src/launcher.dart
+++ b/packages/windows_system/lib/src/launcher.dart
@@ -64,13 +64,13 @@ class Launcher extends IInspectable {
           .launchUriForResultsAsync(uri, options);
 
   static Future<LaunchUriResult?> launchUriForResultsWithDataAsync(
-          Uri? uri, LauncherOptions? options, ValueSet inputData) =>
+          Uri? uri, LauncherOptions? options, ValueSet? inputData) =>
       createActivationFactory(
               ILauncherStatics2.fromPtr, _className, IID_ILauncherStatics2)
           .launchUriForResultsWithDataAsync(uri, options, inputData);
 
   static Future<bool> launchUriWithDataAsync(
-          Uri? uri, LauncherOptions? options, ValueSet inputData) =>
+          Uri? uri, LauncherOptions? options, ValueSet? inputData) =>
       createActivationFactory(
               ILauncherStatics2.fromPtr, _className, IID_ILauncherStatics2)
           .launchUriWithDataAsync(uri, options, inputData);
@@ -162,8 +162,8 @@ class Launcher extends IInspectable {
               ILauncherStatics4.fromPtr, _className, IID_ILauncherStatics4)
           .launchUriWithOptionsForUserAsync(user, uri, options);
 
-  static Future<LaunchUriStatus> launchUriWithDataForUserAsync(
-          User? user, Uri? uri, LauncherOptions? options, ValueSet inputData) =>
+  static Future<LaunchUriStatus> launchUriWithDataForUserAsync(User? user,
+          Uri? uri, LauncherOptions? options, ValueSet? inputData) =>
       createActivationFactory(
               ILauncherStatics4.fromPtr, _className, IID_ILauncherStatics4)
           .launchUriWithDataForUserAsync(user, uri, options, inputData);
@@ -175,7 +175,10 @@ class Launcher extends IInspectable {
           .launchUriForResultsForUserAsync(user, uri, options);
 
   static Future<LaunchUriResult?> launchUriForResultsWithDataForUserAsync(
-          User? user, Uri? uri, LauncherOptions? options, ValueSet inputData) =>
+          User? user,
+          Uri? uri,
+          LauncherOptions? options,
+          ValueSet? inputData) =>
       createActivationFactory(
               ILauncherStatics4.fromPtr, _className, IID_ILauncherStatics4)
           .launchUriForResultsWithDataForUserAsync(

--- a/packages/windows_system/lib/src/user.dart
+++ b/packages/windows_system/lib/src/user.dart
@@ -81,7 +81,7 @@ class User extends IInspectable implements IUser, IUser2 {
       _iUser.getPropertyAsync(value);
 
   @override
-  Future<IPropertySet> getPropertiesAsync(IVectorView<String> values) =>
+  Future<IPropertySet> getPropertiesAsync(IVectorView<String>? values) =>
       _iUser.getPropertiesAsync(values);
 
   @override

--- a/packages/windows_ui/lib/src/notifications/inotificationdatafactory.dart
+++ b/packages/windows_ui/lib/src/notifications/inotificationdatafactory.dart
@@ -29,7 +29,7 @@ class INotificationDataFactory extends IInspectable {
           interface.toInterface(IID_INotificationDataFactory));
 
   NotificationData createNotificationDataWithValuesAndSequenceNumber(
-      IIterable<IKeyValuePair<String, String>> initialValues,
+      IIterable<IKeyValuePair<String, String>>? initialValues,
       int sequenceNumber) {
     final value = calloc<COMObject>();
 
@@ -48,11 +48,13 @@ class INotificationDataFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer initialValues,
                     int sequenceNumber, Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        IInspectable(initialValues
-                .toInterface('{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        initialValues == null
+            ? nullptr
+            : IInspectable(initialValues
+                    .toInterface('{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'))
+                .ptr
+                .ref
+                .lpVtbl,
         sequenceNumber,
         value);
 
@@ -65,7 +67,7 @@ class INotificationDataFactory extends IInspectable {
   }
 
   NotificationData createNotificationDataWithValues(
-      IIterable<IKeyValuePair<String, String>> initialValues) {
+      IIterable<IKeyValuePair<String, String>>? initialValues) {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -82,11 +84,13 @@ class INotificationDataFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer initialValues,
                     Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        IInspectable(initialValues
-                .toInterface('{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'))
-            .ptr
-            .ref
-            .lpVtbl,
+        initialValues == null
+            ? nullptr
+            : IInspectable(initialValues
+                    .toInterface('{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}'))
+                .ptr
+                .ref
+                .lpVtbl,
         value);
 
     if (FAILED(hr)) {

--- a/packages/windows_ui/lib/src/notifications/ischeduledtoastnotificationfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/ischeduledtoastnotificationfactory.dart
@@ -31,7 +31,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
           interface.toInterface(IID_IScheduledToastNotificationFactory));
 
   ScheduledToastNotification createScheduledToastNotification(
-      XmlDocument content, DateTime deliveryTime) {
+      XmlDocument? content, DateTime deliveryTime) {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -49,7 +49,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
                 int Function(VTablePointer lpVtbl, VTablePointer content,
                     int deliveryTime, Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        content.ptr.ref.lpVtbl,
+        content == null ? nullptr : content.ptr.ref.lpVtbl,
         deliveryTime.toWinRTDateTime(),
         value);
 
@@ -62,7 +62,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
   }
 
   ScheduledToastNotification createScheduledToastNotificationRecurring(
-      XmlDocument content,
+      XmlDocument? content,
       DateTime deliveryTime,
       Duration snoozeInterval,
       int maximumSnoozeCount) {
@@ -90,7 +90,7 @@ class IScheduledToastNotificationFactory extends IInspectable {
                     int maximumSnoozeCount,
                     Pointer<COMObject> value)>()(
         ptr.ref.lpVtbl,
-        content.ptr.ref.lpVtbl,
+        content == null ? nullptr : content.ptr.ref.lpVtbl,
         deliveryTime.toWinRTDateTime(),
         snoozeInterval.toWinRTDuration(),
         maximumSnoozeCount,

--- a/packages/windows_ui/lib/src/notifications/itoastcollectionfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastcollectionfactory.dart
@@ -28,8 +28,8 @@ class IToastCollectionFactory extends IInspectable {
       IToastCollectionFactory.fromPtr(
           interface.toInterface(IID_IToastCollectionFactory));
 
-  ToastCollection createInstance(
-      String collectionId, String displayName, String launchArgs, Uri iconUri) {
+  ToastCollection createInstance(String collectionId, String displayName,
+      String launchArgs, Uri? iconUri) {
     final value = calloc<COMObject>();
     final collectionIdHString = collectionId.toHString();
     final displayNameHString = displayName.toHString();
@@ -60,7 +60,7 @@ class IToastCollectionFactory extends IInspectable {
         collectionIdHString,
         displayNameHString,
         launchArgsHString,
-        iconUri.toWinRTUri().ptr.ref.lpVtbl,
+        iconUri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr,
         value);
 
     WindowsDeleteString(collectionIdHString);

--- a/packages/windows_ui/lib/src/notifications/itoastnotificationfactory.dart
+++ b/packages/windows_ui/lib/src/notifications/itoastnotificationfactory.dart
@@ -29,7 +29,7 @@ class IToastNotificationFactory extends IInspectable {
       IToastNotificationFactory.fromPtr(
           interface.toInterface(IID_IToastNotificationFactory));
 
-  ToastNotification createToastNotification(XmlDocument content) {
+  ToastNotification createToastNotification(XmlDocument? content) {
     final value = calloc<COMObject>();
 
     final hr =
@@ -45,8 +45,8 @@ class IToastNotificationFactory extends IInspectable {
                 .value
                 .asFunction<
                     int Function(VTablePointer lpVtbl, VTablePointer content,
-                        Pointer<COMObject> value)>()(
-            ptr.ref.lpVtbl, content.ptr.ref.lpVtbl, value);
+                        Pointer<COMObject> value)>()(ptr.ref.lpVtbl,
+            content == null ? nullptr : content.ptr.ref.lpVtbl, value);
 
     if (FAILED(hr)) {
       free(value);

--- a/packages/windows_ui/lib/src/notifications/notificationdata.dart
+++ b/packages/windows_ui/lib/src/notifications/notificationdata.dart
@@ -26,7 +26,7 @@ class NotificationData extends IInspectable implements INotificationData {
   static const _className = 'Windows.UI.Notifications.NotificationData';
 
   factory NotificationData.createNotificationDataWithValuesAndSequenceNumber(
-          IIterable<IKeyValuePair<String, String>> initialValues,
+          IIterable<IKeyValuePair<String, String>>? initialValues,
           int sequenceNumber) =>
       createActivationFactory(INotificationDataFactory.fromPtr, _className,
               IID_INotificationDataFactory)
@@ -34,7 +34,7 @@ class NotificationData extends IInspectable implements INotificationData {
               initialValues, sequenceNumber);
 
   factory NotificationData.createNotificationDataWithValues(
-          IIterable<IKeyValuePair<String, String>> initialValues) =>
+          IIterable<IKeyValuePair<String, String>>? initialValues) =>
       createActivationFactory(INotificationDataFactory.fromPtr, _className,
               IID_INotificationDataFactory)
           .createNotificationDataWithValues(initialValues);

--- a/packages/windows_ui/lib/src/notifications/scheduledtoastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/scheduledtoastnotification.dart
@@ -37,13 +37,13 @@ class ScheduledToastNotification extends IInspectable
       'Windows.UI.Notifications.ScheduledToastNotification';
 
   factory ScheduledToastNotification.createScheduledToastNotification(
-          XmlDocument content, DateTime deliveryTime) =>
+          XmlDocument? content, DateTime deliveryTime) =>
       createActivationFactory(IScheduledToastNotificationFactory.fromPtr,
               _className, IID_IScheduledToastNotificationFactory)
           .createScheduledToastNotification(content, deliveryTime);
 
   factory ScheduledToastNotification.createScheduledToastNotificationRecurring(
-          XmlDocument content,
+          XmlDocument? content,
           DateTime deliveryTime,
           Duration snoozeInterval,
           int maximumSnoozeCount) =>

--- a/packages/windows_ui/lib/src/notifications/toastcollection.dart
+++ b/packages/windows_ui/lib/src/notifications/toastcollection.dart
@@ -25,7 +25,7 @@ class ToastCollection extends IInspectable implements IToastCollection {
   static const _className = 'Windows.UI.Notifications.ToastCollection';
 
   factory ToastCollection.createInstance(String collectionId,
-          String displayName, String launchArgs, Uri iconUri) =>
+          String displayName, String launchArgs, Uri? iconUri) =>
       createActivationFactory(IToastCollectionFactory.fromPtr, _className,
               IID_IToastCollectionFactory)
           .createInstance(collectionId, displayName, launchArgs, iconUri);

--- a/packages/windows_ui/lib/src/notifications/toastnotification.dart
+++ b/packages/windows_ui/lib/src/notifications/toastnotification.dart
@@ -39,7 +39,7 @@ class ToastNotification extends IInspectable
 
   static const _className = 'Windows.UI.Notifications.ToastNotification';
 
-  factory ToastNotification.createToastNotification(XmlDocument content) =>
+  factory ToastNotification.createToastNotification(XmlDocument? content) =>
       createActivationFactory(IToastNotificationFactory.fromPtr, _className,
               IID_IToastNotificationFactory)
           .createToastNotification(content);

--- a/packages/winrtgen/lib/src/projections/parameter.dart
+++ b/packages/winrtgen/lib/src/projections/parameter.dart
@@ -93,6 +93,8 @@ abstract class ParameterProjection {
 
   bool get isOutParam => parameter.isOutParam;
 
+  bool get isReturnParam => !isInParam && !isOutParam;
+
   String get ffiProjection => '${typeProjection.nativeType} $identifier';
 
   String get dartProjection => '${typeProjection.dartType} $identifier';

--- a/packages/winrtgen/lib/src/projections/types/map.dart
+++ b/packages/winrtgen/lib/src/projections/types/map.dart
@@ -65,15 +65,21 @@ final class MapParameterProjection extends ParameterProjection {
   }
 
   @override
-  String get type => 'IMap<$mapTypeArgs>';
+  bool get isNullable {
+    if (isReturnParam) return false;
+    // TODO(halildurmus): Remove this
+    if (isOutParam) return false;
+    return true;
+  }
+
+  @override
+  String get type => isNullable ? 'IMap<$mapTypeArgs>?' : 'IMap<$mapTypeArgs>';
 
   @override
   String get creator => 'IMap.fromPtr($identifier$mapConstructorArgs)';
 
   @override
-  String get into => typeProjection.isReferenceType
-      ? '$identifier.ptr'
-      : '$identifier.ptr.ref.lpVtbl';
+  String get into => '$identifier?.ptr.ref.lpVtbl ?? nullptr';
 
   // No deallocation is needed as Finalizer will handle it.
   @override
@@ -84,11 +90,13 @@ final class MapViewParameterProjection extends MapParameterProjection {
   MapViewParameterProjection(super.parameter);
 
   @override
-  String get type => isInParam || isOutParam
-      ? typeProjection.typeIdentifier.shortName
-      : 'Map<$mapTypeArgs>';
+  String get type {
+    if (isInParam) return 'IMapView<$mapTypeArgs>?';
+    if (isOutParam) return 'IMapView<$mapTypeArgs>';
+    return isNullable ? 'Map<$mapTypeArgs>?' : 'Map<$mapTypeArgs>';
+  }
 
   @override
   String get creator =>
-      'IMapView<$mapTypeArgs>.fromPtr($localIdentifier$mapConstructorArgs).toMap()';
+      'IMapView<$mapTypeArgs>.fromPtr($identifier$mapConstructorArgs).toMap()';
 }

--- a/packages/winrtgen/lib/src/projections/types/uri.dart
+++ b/packages/winrtgen/lib/src/projections/types/uri.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import '../../utilities/utilities.dart';
+import '../../utilities/extensions/extensions.dart';
 import '../parameter.dart';
 
 /// Parameter projection for `Uri` parameters.
@@ -10,7 +10,12 @@ final class UriParameterProjection extends ParameterProjection {
   UriParameterProjection(super.parameter);
 
   @override
-  bool get isNullable => !method.parent.isFactoryInterface;
+  bool get isNullable {
+    // Constructors cannot return null.
+    if (isReturnParam && method.parent.isFactoryInterface) return false;
+    // Treat everything else as nullable.
+    return true;
+  }
 
   @override
   String get type => isNullable ? 'Uri?' : 'Uri';
@@ -25,11 +30,8 @@ final class UriParameterProjection extends ParameterProjection {
     final buffer = StringBuffer()..write(identifier);
     if (isNullable) buffer.write('?');
     if (needsConversionToWinRTUri) buffer.write('.toWinRTUri()');
-    buffer.write('.ptr');
-    if (!typeProjection.isReferenceType) {
-      buffer.write('.ref.lpVtbl');
-      if (isNullable) buffer.write(' ?? nullptr');
-    }
+    buffer.write('.ptr.ref.lpVtbl');
+    if (isNullable) buffer.write(' ?? nullptr');
     return buffer.toString();
   }
 

--- a/packages/winrtgen/lib/src/projections/types/vector.dart
+++ b/packages/winrtgen/lib/src/projections/types/vector.dart
@@ -63,15 +63,22 @@ final class VectorParameterProjection extends ParameterProjection {
   }
 
   @override
-  String get type => 'IVector<$vectorTypeArg>';
+  bool get isNullable {
+    if (isReturnParam) return false;
+    // TODO(halildurmus): Remove this
+    if (isOutParam) return false;
+    return true;
+  }
+
+  @override
+  String get type =>
+      isNullable ? 'IVector<$vectorTypeArg>?' : 'IVector<$vectorTypeArg>';
 
   @override
   String get creator => 'IVector.fromPtr($identifier$vectorConstructorArgs)';
 
   @override
-  String get into => typeProjection.isReferenceType
-      ? '$identifier.ptr'
-      : '$identifier.ptr.ref.lpVtbl';
+  String get into => '$identifier?.ptr.ref.lpVtbl ?? nullptr';
 
   // No deallocation is needed as Finalizer will handle it.
   @override
@@ -82,11 +89,13 @@ final class VectorViewParameterProjection extends VectorParameterProjection {
   VectorViewParameterProjection(super.parameter);
 
   @override
-  String get type => isInParam || isOutParam
-      ? typeProjection.typeIdentifier.shortName
-      : 'List<$vectorTypeArg>';
+  String get type {
+    if (isInParam) return 'IVectorView<$vectorTypeArg>?';
+    if (isOutParam) return 'IVectorView<$vectorTypeArg>';
+    return isNullable ? 'List<$vectorTypeArg>?' : 'List<$vectorTypeArg>';
+  }
 
   @override
   String get creator =>
-      'IVectorView<$vectorTypeArg>.fromPtr($localIdentifier$vectorConstructorArgs).toList()';
+      'IVectorView<$vectorTypeArg>.fromPtr($identifier$vectorConstructorArgs).toList()';
 }

--- a/packages/winrtgen/lib/src/utilities/extensions/type_identifier_helpers.dart
+++ b/packages/winrtgen/lib/src/utilities/extensions/type_identifier_helpers.dart
@@ -53,6 +53,8 @@ extension TypeIdentifierHelpers on TypeIdentifier {
   bool get isClassVariableType =>
       baseType == BaseType.classVariableTypeModifier;
 
+  bool get isCollectionObject => type?.isCollectionObject ?? false;
+
   bool get isGenericType => baseType == BaseType.genericTypeModifier;
 
   bool get isObjectType => baseType == BaseType.objectType;
@@ -243,7 +245,7 @@ String _parseTypeArgName(TypeIdentifier typeIdentifier) {
   // Value types (enums and structs) cannot be null.
   if (TypeProjection(typeIdentifier).isValueType) return typeArg;
   // Collection interfaces cannot be null.
-  if (typeIdentifier.type?.isCollectionObject ?? false) return typeArg;
+  if (typeIdentifier.isCollectionObject) return typeArg;
   // Primitive types cannot be null.
   if (typeArg case 'bool' || 'double' || 'int' || 'String') return typeArg;
   // Otherwise, mark typeArg as nullable.

--- a/packages/winrtgen/test/projections/parameter_test.dart
+++ b/packages/winrtgen/test/projections/parameter_test.dart
@@ -407,8 +407,8 @@ void main() {
       expect(projection, isA<MapParameterProjection>());
       expect(projection.isInParam, isTrue);
       expect(projection.isOutParam, isFalse);
-      expect(projection.isNullable, isFalse);
-      expect(projection.type, equals('IMap<String, Object?>'));
+      expect(projection.isNullable, isTrue);
+      expect(projection.type, equals('IMap<String, Object?>?'));
       expect(projection.needsAllocation, isFalse);
       expect(projection.needsDeallocation, isFalse);
       expect(projection.creatorPreamble, isEmpty);
@@ -416,7 +416,7 @@ void main() {
           projection.creator,
           equals(
               "IMap.fromPtr(features, iterableIid: '{fe2f3d47-5d47-5499-8374-430c7cda0204}')"));
-      expect(projection.into, equals('features.ptr.ref.lpVtbl'));
+      expect(projection.into, equals('features?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.toListArg, isEmpty);
       expect(projection.toListCreator, isEmpty);
       expect(projection.toListInto, isEmpty);
@@ -425,7 +425,8 @@ void main() {
       expect(projection.postambles, isEmpty);
       expect(projection.nullCheck, isEmpty);
       expect(projection.identifier, equals('features'));
-      expect(projection.localIdentifier, equals('features.ptr.ref.lpVtbl'));
+      expect(projection.localIdentifier,
+          equals('features?.ptr.ref.lpVtbl ?? nullptr'));
     });
 
     test('projects IMapView<String, Object?>', () {
@@ -445,7 +446,7 @@ void main() {
         IMapView<String, Object?>.fromPtr(first,
             iterableIid: '{fe2f3d47-5d47-5499-8374-430c7cda0204}').toMap()
 '''));
-      expect(projection.into, equals('first.ptr'));
+      expect(projection.into, equals('first?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.toListArg, isEmpty);
       expect(projection.toListCreator, isEmpty);
       expect(projection.toListInto, isEmpty);
@@ -532,8 +533,8 @@ void main() {
       expect(projection, isA<VectorParameterProjection>());
       expect(projection.isInParam, isTrue);
       expect(projection.isOutParam, isFalse);
-      expect(projection.isNullable, isFalse);
-      expect(projection.type, equals('IVector<HostName?>'));
+      expect(projection.isNullable, isTrue);
+      expect(projection.type, equals('IVector<HostName?>?'));
       expect(projection.needsAllocation, isFalse);
       expect(projection.needsDeallocation, isFalse);
       expect(projection.creatorPreamble, isEmpty);
@@ -542,7 +543,8 @@ void main() {
           iterableIid: '{9e5f3ed0-cf1c-5d38-832c-acea6164bf5c}',
           creator: HostName.fromPtr)
 '''));
-      expect(projection.into, equals('dnsServerList.ptr.ref.lpVtbl'));
+      expect(
+          projection.into, equals('dnsServerList?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.toListArg, isEmpty);
       expect(projection.toListCreator, isEmpty);
       expect(projection.toListInto, isEmpty);
@@ -551,8 +553,8 @@ void main() {
       expect(projection.postambles, isEmpty);
       expect(projection.nullCheck, isEmpty);
       expect(projection.identifier, equals('dnsServerList'));
-      expect(
-          projection.localIdentifier, equals('dnsServerList.ptr.ref.lpVtbl'));
+      expect(projection.localIdentifier,
+          equals('dnsServerList?.ptr.ref.lpVtbl ?? nullptr'));
     });
 
     test('projects IVectorView<String>', () {
@@ -562,16 +564,16 @@ void main() {
       expect(projection, isA<VectorViewParameterProjection>());
       expect(projection.isInParam, isTrue);
       expect(projection.isOutParam, isFalse);
-      expect(projection.isNullable, isFalse);
-      expect(projection.type, equals('IVectorView<String>'));
+      expect(projection.isNullable, isTrue);
+      expect(projection.type, equals('IVectorView<String>?'));
       expect(projection.needsAllocation, isFalse);
       expect(projection.needsDeallocation, isFalse);
       expect(projection.creatorPreamble, isEmpty);
       expect(projection.creator, equalsIgnoringWhitespace('''
-        IVectorView<String>.fromPtr(values.ptr.ref.lpVtbl,
+        IVectorView<String>.fromPtr(values,
             iterableIid: '{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}').toList()
 '''));
-      expect(projection.into, equals('values.ptr.ref.lpVtbl'));
+      expect(projection.into, equals('values?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.toListArg, isEmpty);
       expect(projection.toListCreator, isEmpty);
       expect(projection.toListInto, isEmpty);
@@ -580,7 +582,8 @@ void main() {
       expect(projection.postambles, isEmpty);
       expect(projection.nullCheck, isEmpty);
       expect(projection.identifier, equals('values'));
-      expect(projection.localIdentifier, equals('values.ptr.ref.lpVtbl'));
+      expect(projection.localIdentifier,
+          equals('values?.ptr.ref.lpVtbl ?? nullptr'));
     });
 
     test('projects List<Point> (FillArray)', () {
@@ -918,24 +921,25 @@ void main() {
       expect(projection, isA<UriParameterProjection>());
       expect(projection.isInParam, isTrue);
       expect(projection.isOutParam, isFalse);
-      expect(projection.isNullable, isFalse);
-      expect(projection.type, equals('Uri'));
+      expect(projection.isNullable, isTrue);
+      expect(projection.type, equals('Uri?'));
       expect(projection.needsAllocation, isFalse);
       expect(projection.needsDeallocation, isFalse);
       expect(projection.creatorPreamble, isEmpty);
       expect(projection.creator, equals('iconUri.toWinRTUri().toDartUri()'));
-      expect(projection.into, equals('iconUri.toWinRTUri().ptr.ref.lpVtbl'));
+      expect(projection.into,
+          equals('iconUri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.toListArg, isEmpty);
       expect(projection.toListCreator, isEmpty);
       expect(projection.toListInto,
           equals('iconUri[i]?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.toListIdentifier, equals('toDartUriList'));
       expect(projection.preambles, isEmpty);
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('iconUri')));
       expect(projection.postambles, isEmpty);
       expect(projection.identifier, equals('iconUri'));
       expect(projection.localIdentifier,
-          equals('iconUri.toWinRTUri().ptr.ref.lpVtbl'));
+          equals('iconUri?.toWinRTUri().ptr.ref.lpVtbl ?? nullptr'));
     });
 
     test('projects Uri?', () {

--- a/packages/winrtgen/test/projections/setter_test.dart
+++ b/packages/winrtgen/test/projections/setter_test.dart
@@ -360,7 +360,7 @@ void main() {
       expect(projection.useTryFinallyBlock, isFalse);
       expect(projection.returnType, isEmpty);
       expect(projection.header,
-          equals('set dnsServers(IVector<HostName?> value)'));
+          equals('set dnsServers(IVector<HostName?>? value)'));
       expect(projection.paramIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.parametersPreamble, isEmpty);
@@ -371,7 +371,7 @@ void main() {
       expect(projection.dartPrototype,
           equals('int Function(VTablePointer lpVtbl, VTablePointer value)'));
       expect(projection.identifiers,
-          equals('ptr.ref.lpVtbl, value.ptr.ref.lpVtbl'));
+          equals('ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);
@@ -386,7 +386,7 @@ void main() {
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
       expect(projection.returnType, isEmpty);
-      expect(projection.header, equals('set items(IVector<Object?> value)'));
+      expect(projection.header, equals('set items(IVector<Object?>? value)'));
       expect(projection.paramIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.parametersPreamble, isEmpty);
@@ -397,7 +397,7 @@ void main() {
       expect(projection.dartPrototype,
           equals('int Function(VTablePointer lpVtbl, VTablePointer value)'));
       expect(projection.identifiers,
-          equals('ptr.ref.lpVtbl, value.ptr.ref.lpVtbl'));
+          equals('ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);
@@ -413,7 +413,7 @@ void main() {
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
       expect(projection.returnType, isEmpty);
-      expect(projection.header, equals('set ratings(IVector<String> value)'));
+      expect(projection.header, equals('set ratings(IVector<String>? value)'));
       expect(projection.paramIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.parametersPreamble, isEmpty);
@@ -424,7 +424,7 @@ void main() {
       expect(projection.dartPrototype,
           equals('int Function(VTablePointer lpVtbl, VTablePointer value)'));
       expect(projection.identifiers,
-          equals('ptr.ref.lpVtbl, value.ptr.ref.lpVtbl'));
+          equals('ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);
@@ -441,7 +441,7 @@ void main() {
       expect(projection.useTryFinallyBlock, isFalse);
       expect(projection.returnType, isEmpty);
       expect(projection.header,
-          equals('set displayItems(IVectorView<PaymentItem?> value)'));
+          equals('set displayItems(IVectorView<PaymentItem?>? value)'));
       expect(projection.paramIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.parametersPreamble, isEmpty);
@@ -452,7 +452,7 @@ void main() {
       expect(projection.dartPrototype,
           equals('int Function(VTablePointer lpVtbl, VTablePointer value)'));
       expect(projection.identifiers,
-          equals('ptr.ref.lpVtbl, value.ptr.ref.lpVtbl'));
+          equals('ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);
@@ -469,7 +469,7 @@ void main() {
       expect(projection.useTryFinallyBlock, isFalse);
       expect(projection.returnType, isEmpty);
       expect(projection.header,
-          equals('set languages(IVectorView<String> languages)'));
+          equals('set languages(IVectorView<String>? languages)'));
       expect(projection.paramIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.parametersPreamble, isEmpty);
@@ -482,7 +482,7 @@ void main() {
           equals(
               'int Function(VTablePointer lpVtbl, VTablePointer languages)'));
       expect(projection.identifiers,
-          equals('ptr.ref.lpVtbl, languages.ptr.ref.lpVtbl'));
+          equals('ptr.ref.lpVtbl, languages?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Parameters of type `Uri` and WinRT object are now nullable in constructors and methods.

## Related Issue

Fixes #292 
Fixes #293

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🧪 `test` -- Test
- [ ] 🗑️ `chore` -- Chore
