### PR TITLE
fix!: getters that return collection objects are now nullable

### DIFF
--- a/packages/windows_ai/example/machinelearning/main.dart
+++ b/packages/windows_ai/example/machinelearning/main.dart
@@ -111,7 +111,7 @@ void main() async {
   final results = session.evaluate(binding, 'RunId')!;
 
   // Get the output
-  final resultTensor = results.outputs['softmaxout_1'];
+  final resultTensor = results.outputs?['softmaxout_1'];
 
   if (resultTensor is IInspectable) {
     // Cast it to TensorFloat

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodel.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodel.dart
@@ -151,7 +151,7 @@ class ILearningModel extends IInspectable {
     }
   }
 
-  Map<String, String> get metadata {
+  Map<String, String>? get metadata {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -171,12 +171,17 @@ class ILearningModel extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IMapView<String, String>.fromPtr(value,
             iterableIid: '{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}')
         .toMap();
   }
 
-  List<ILearningModelFeatureDescriptor?> get inputFeatures {
+  List<ILearningModelFeatureDescriptor?>? get inputFeatures {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -196,13 +201,18 @@ class ILearningModel extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IVectorView<ILearningModelFeatureDescriptor?>.fromPtr(value,
             iterableIid: '{0fa50877-6792-56b7-af46-430a8901894a}',
             creator: ILearningModelFeatureDescriptor.fromPtr)
         .toList();
   }
 
-  List<ILearningModelFeatureDescriptor?> get outputFeatures {
+  List<ILearningModelFeatureDescriptor?>? get outputFeatures {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -220,6 +230,11 @@ class ILearningModel extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<ILearningModelFeatureDescriptor?>.fromPtr(value,

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelevaluationresult.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelevaluationresult.dart
@@ -100,7 +100,7 @@ class ILearningModelEvaluationResult extends IInspectable {
     }
   }
 
-  Map<String, Object?> get outputs {
+  Map<String, Object?>? get outputs {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -118,6 +118,11 @@ class ILearningModelEvaluationResult extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMapView<String, Object?>.fromPtr(value,

--- a/packages/windows_ai/lib/src/machinelearning/ilearningmodelsession.dart
+++ b/packages/windows_ai/lib/src/machinelearning/ilearningmodelsession.dart
@@ -87,7 +87,7 @@ class ILearningModelSession extends IInspectable {
     return LearningModelDevice.fromPtr(value);
   }
 
-  IPropertySet get evaluationProperties {
+  IPropertySet? get evaluationProperties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -105,6 +105,11 @@ class ILearningModelSession extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IPropertySet.fromPtr(value);

--- a/packages/windows_ai/lib/src/machinelearning/itensor.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensor.dart
@@ -53,7 +53,7 @@ class ITensor extends IInspectable implements ILearningModelFeatureValue {
     }
   }
 
-  List<int> get shape {
+  List<int>? get shape {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -71,6 +71,11 @@ class ITensor extends IInspectable implements ILearningModelFeatureValue {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<int>.fromPtr(value,

--- a/packages/windows_ai/lib/src/machinelearning/itensorfeaturedescriptor.dart
+++ b/packages/windows_ai/lib/src/machinelearning/itensorfeaturedescriptor.dart
@@ -52,7 +52,7 @@ class ITensorFeatureDescriptor extends IInspectable {
     }
   }
 
-  List<int> get shape {
+  List<int>? get shape {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -70,6 +70,11 @@ class ITensorFeatureDescriptor extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<int>.fromPtr(value,

--- a/packages/windows_ai/lib/src/machinelearning/learningmodel.dart
+++ b/packages/windows_ai/lib/src/machinelearning/learningmodel.dart
@@ -97,14 +97,14 @@ class LearningModel extends IInspectable implements ILearningModel, IClosable {
   int get version => _iLearningModel.version;
 
   @override
-  Map<String, String> get metadata => _iLearningModel.metadata;
+  Map<String, String>? get metadata => _iLearningModel.metadata;
 
   @override
-  List<ILearningModelFeatureDescriptor?> get inputFeatures =>
+  List<ILearningModelFeatureDescriptor?>? get inputFeatures =>
       _iLearningModel.inputFeatures;
 
   @override
-  List<ILearningModelFeatureDescriptor?> get outputFeatures =>
+  List<ILearningModelFeatureDescriptor?>? get outputFeatures =>
       _iLearningModel.outputFeatures;
 
   late final _iClosable = IClosable.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/learningmodelevaluationresult.dart
+++ b/packages/windows_ai/lib/src/machinelearning/learningmodelevaluationresult.dart
@@ -35,5 +35,5 @@ class LearningModelEvaluationResult extends IInspectable
   bool get succeeded => _iLearningModelEvaluationResult.succeeded;
 
   @override
-  Map<String, Object?> get outputs => _iLearningModelEvaluationResult.outputs;
+  Map<String, Object?>? get outputs => _iLearningModelEvaluationResult.outputs;
 }

--- a/packages/windows_ai/lib/src/machinelearning/learningmodelsession.dart
+++ b/packages/windows_ai/lib/src/machinelearning/learningmodelsession.dart
@@ -60,7 +60,7 @@ class LearningModelSession extends IInspectable
   LearningModelDevice? get device => _iLearningModelSession.device;
 
   @override
-  IPropertySet get evaluationProperties =>
+  IPropertySet? get evaluationProperties =>
       _iLearningModelSession.evaluationProperties;
 
   @override

--- a/packages/windows_ai/lib/src/machinelearning/tensorboolean.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorboolean.dart
@@ -79,7 +79,7 @@ class TensorBoolean extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensordouble.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensordouble.dart
@@ -79,7 +79,7 @@ class TensorDouble extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorfeaturedescriptor.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorfeaturedescriptor.dart
@@ -31,7 +31,7 @@ class TensorFeatureDescriptor extends IInspectable
   TensorKind get tensorKind => _iTensorFeatureDescriptor.tensorKind;
 
   @override
-  List<int> get shape => _iTensorFeatureDescriptor.shape;
+  List<int>? get shape => _iTensorFeatureDescriptor.shape;
 
   late final _iLearningModelFeatureDescriptor =
       ILearningModelFeatureDescriptor.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorfloat.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorfloat.dart
@@ -78,7 +78,7 @@ class TensorFloat extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorfloat16bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorfloat16bit.dart
@@ -81,7 +81,7 @@ class TensorFloat16Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorint16bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorint16bit.dart
@@ -81,7 +81,7 @@ class TensorInt16Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorint32bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorint32bit.dart
@@ -81,7 +81,7 @@ class TensorInt32Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorint64bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorint64bit.dart
@@ -81,7 +81,7 @@ class TensorInt64Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorint8bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorint8bit.dart
@@ -79,7 +79,7 @@ class TensorInt8Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensorstring.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensorstring.dart
@@ -73,7 +73,7 @@ class TensorString extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensoruint16bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensoruint16bit.dart
@@ -81,7 +81,7 @@ class TensorUInt16Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensoruint32bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensoruint32bit.dart
@@ -81,7 +81,7 @@ class TensorUInt32Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensoruint64bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensoruint64bit.dart
@@ -81,7 +81,7 @@ class TensorUInt64Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_ai/lib/src/machinelearning/tensoruint8bit.dart
+++ b/packages/windows_ai/lib/src/machinelearning/tensoruint8bit.dart
@@ -81,7 +81,7 @@ class TensorUInt8Bit extends IInspectable
   TensorKind get tensorKind => _iTensor.tensorKind;
 
   @override
-  List<int> get shape => _iTensor.shape;
+  List<int>? get shape => _iTensor.shape;
 
   late final _iLearningModelFeatureValue =
       ILearningModelFeatureValue.from(this);

--- a/packages/windows_applicationmodel/lib/src/appinstallerinfo.dart
+++ b/packages/windows_applicationmodel/lib/src/appinstallerinfo.dart
@@ -68,17 +68,18 @@ class AppInstallerInfo extends IInspectable
   DateTime? get pausedUntil => _iAppInstallerInfo2.pausedUntil;
 
   @override
-  List<Uri?> get updateUris => _iAppInstallerInfo2.updateUris;
+  List<Uri?>? get updateUris => _iAppInstallerInfo2.updateUris;
 
   @override
-  List<Uri?> get repairUris => _iAppInstallerInfo2.repairUris;
+  List<Uri?>? get repairUris => _iAppInstallerInfo2.repairUris;
 
   @override
-  List<Uri?> get dependencyPackageUris =>
+  List<Uri?>? get dependencyPackageUris =>
       _iAppInstallerInfo2.dependencyPackageUris;
 
   @override
-  List<Uri?> get optionalPackageUris => _iAppInstallerInfo2.optionalPackageUris;
+  List<Uri?>? get optionalPackageUris =>
+      _iAppInstallerInfo2.optionalPackageUris;
 
   @override
   AppInstallerPolicySource get policySource => _iAppInstallerInfo2.policySource;

--- a/packages/windows_applicationmodel/lib/src/iappinstallerinfo2.dart
+++ b/packages/windows_applicationmodel/lib/src/iappinstallerinfo2.dart
@@ -275,7 +275,7 @@ class IAppInstallerInfo2 extends IInspectable {
         .value;
   }
 
-  List<Uri?> get updateUris {
+  List<Uri?>? get updateUris {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -295,12 +295,17 @@ class IAppInstallerInfo2 extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IVectorView<Uri?>.fromPtr(value,
             iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}')
         .toList();
   }
 
-  List<Uri?> get repairUris {
+  List<Uri?>? get repairUris {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -320,12 +325,17 @@ class IAppInstallerInfo2 extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IVectorView<Uri?>.fromPtr(value,
             iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}')
         .toList();
   }
 
-  List<Uri?> get dependencyPackageUris {
+  List<Uri?>? get dependencyPackageUris {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -345,12 +355,17 @@ class IAppInstallerInfo2 extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IVectorView<Uri?>.fromPtr(value,
             iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}')
         .toList();
   }
 
-  List<Uri?> get optionalPackageUris {
+  List<Uri?>? get optionalPackageUris {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -368,6 +383,11 @@ class IAppInstallerInfo2 extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<Uri?>.fromPtr(value,

--- a/packages/windows_applicationmodel/lib/src/ipackage.dart
+++ b/packages/windows_applicationmodel/lib/src/ipackage.dart
@@ -109,7 +109,7 @@ class IPackage extends IInspectable {
     }
   }
 
-  List<Package?> get dependencies {
+  List<Package?>? get dependencies {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -127,6 +127,11 @@ class IPackage extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<Package?>.fromPtr(value,

--- a/packages/windows_applicationmodel/lib/src/package.dart
+++ b/packages/windows_applicationmodel/lib/src/package.dart
@@ -69,7 +69,7 @@ class Package extends IInspectable
   bool get isFramework => _iPackage.isFramework;
 
   @override
-  List<Package?> get dependencies => _iPackage.dependencies;
+  List<Package?>? get dependencies => _iPackage.dependencies;
 
   late final _iPackage2 = IPackage2.from(this);
 

--- a/packages/windows_data/example/xmldom.dart
+++ b/packages/windows_data/example/xmldom.dart
@@ -9,9 +9,10 @@ import 'package:windows_data/windows_data.dart';
 
 void printProduct(IXmlNode? product) {
   if (product == null) return;
-  final id = product.attributes.getNamedItem('id')?.nodeValue;
-  final title = product.attributes.getNamedItem('title')?.nodeValue;
-  final hot = product.attributes.getNamedItem('hot')?.nodeValue;
+  final attributes = product.attributes;
+  final id = attributes?.getNamedItem('id')?.nodeValue;
+  final title = attributes?.getNamedItem('title')?.nodeValue;
+  final hot = attributes?.getNamedItem('hot')?.nodeValue;
   final price = product.selectNodes('price').item(0)?.firstChild?.nodeValue;
   print('Product id: $id, title: $title, hot: $hot, price: $price');
 }

--- a/packages/windows_data/lib/src/xml/dom/ixmlattribute.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlattribute.dart
@@ -146,7 +146,7 @@ class IXmlAttribute extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -161,7 +161,7 @@ class IXmlAttribute extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmlcdatasection.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlcdatasection.dart
@@ -94,7 +94,7 @@ class IXmlCDataSection extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -109,7 +109,7 @@ class IXmlCDataSection extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmlcharacterdata.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlcharacterdata.dart
@@ -220,7 +220,7 @@ class IXmlCharacterData extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -235,7 +235,7 @@ class IXmlCharacterData extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmlcomment.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlcomment.dart
@@ -87,7 +87,7 @@ class IXmlComment extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -102,7 +102,7 @@ class IXmlComment extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmldocument.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocument.dart
@@ -598,7 +598,7 @@ class IXmlDocument extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -613,7 +613,7 @@ class IXmlDocument extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmldocumentfragment.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocumentfragment.dart
@@ -53,7 +53,7 @@ class IXmlDocumentFragment extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -68,7 +68,7 @@ class IXmlDocumentFragment extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmldocumenttype.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmldocumenttype.dart
@@ -59,7 +59,7 @@ class IXmlDocumentType extends IInspectable
     }
   }
 
-  XmlNamedNodeMap get entities {
+  XmlNamedNodeMap? get entities {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -79,10 +79,15 @@ class IXmlDocumentType extends IInspectable
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return XmlNamedNodeMap.fromPtr(value);
   }
 
-  XmlNamedNodeMap get notations {
+  XmlNamedNodeMap? get notations {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -100,6 +105,11 @@ class IXmlDocumentType extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return XmlNamedNodeMap.fromPtr(value);
@@ -123,7 +133,7 @@ class IXmlDocumentType extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -138,7 +148,7 @@ class IXmlDocumentType extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmlelement.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlelement.dart
@@ -434,7 +434,7 @@ class IXmlElement extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -449,7 +449,7 @@ class IXmlElement extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmlentityreference.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlentityreference.dart
@@ -53,7 +53,7 @@ class IXmlEntityReference extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -68,7 +68,7 @@ class IXmlEntityReference extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmlnode.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlnode.dart
@@ -159,7 +159,7 @@ class IXmlNode extends IInspectable
     return IXmlNode.fromPtr(value);
   }
 
-  XmlNodeList get childNodes {
+  XmlNodeList? get childNodes {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -177,6 +177,11 @@ class IXmlNode extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return XmlNodeList.fromPtr(value);
@@ -294,7 +299,7 @@ class IXmlNode extends IInspectable
     return IXmlNode.fromPtr(value);
   }
 
-  XmlNamedNodeMap get attributes {
+  XmlNamedNodeMap? get attributes {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -312,6 +317,11 @@ class IXmlNode extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return XmlNamedNodeMap.fromPtr(value);

--- a/packages/windows_data/lib/src/xml/dom/ixmlprocessinginstruction.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmlprocessinginstruction.dart
@@ -123,7 +123,7 @@ class IXmlProcessingInstruction extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -138,7 +138,7 @@ class IXmlProcessingInstruction extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/ixmltext.dart
+++ b/packages/windows_data/lib/src/xml/dom/ixmltext.dart
@@ -116,7 +116,7 @@ class IXmlText extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -131,7 +131,7 @@ class IXmlText extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmlattribute.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlattribute.dart
@@ -62,7 +62,7 @@ class XmlAttribute extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -77,7 +77,7 @@ class XmlAttribute extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmlcdatasection.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlcdatasection.dart
@@ -90,7 +90,7 @@ class XmlCDataSection extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -105,7 +105,7 @@ class XmlCDataSection extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmlcomment.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlcomment.dart
@@ -83,7 +83,7 @@ class XmlComment extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -98,7 +98,7 @@ class XmlComment extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmldocument.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmldocument.dart
@@ -158,7 +158,7 @@ class XmlDocument extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -173,7 +173,7 @@ class XmlDocument extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmldocumentfragment.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmldocumentfragment.dart
@@ -52,7 +52,7 @@ class XmlDocumentFragment extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -67,7 +67,7 @@ class XmlDocumentFragment extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmldocumenttype.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmldocumenttype.dart
@@ -39,10 +39,10 @@ class XmlDocumentType extends IInspectable
   String get name => _iXmlDocumentType.name;
 
   @override
-  XmlNamedNodeMap get entities => _iXmlDocumentType.entities;
+  XmlNamedNodeMap? get entities => _iXmlDocumentType.entities;
 
   @override
-  XmlNamedNodeMap get notations => _iXmlDocumentType.notations;
+  XmlNamedNodeMap? get notations => _iXmlDocumentType.notations;
 
   late final _iXmlNode = IXmlNode.from(this);
 
@@ -62,7 +62,7 @@ class XmlDocumentType extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -77,7 +77,7 @@ class XmlDocumentType extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmlelement.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlelement.dart
@@ -102,7 +102,7 @@ class XmlElement extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -117,7 +117,7 @@ class XmlElement extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmlentityreference.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlentityreference.dart
@@ -51,7 +51,7 @@ class XmlEntityReference extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -66,7 +66,7 @@ class XmlEntityReference extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmlprocessinginstruction.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmlprocessinginstruction.dart
@@ -63,7 +63,7 @@ class XmlProcessingInstruction extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -78,7 +78,7 @@ class XmlProcessingInstruction extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_data/lib/src/xml/dom/xmltext.dart
+++ b/packages/windows_data/lib/src/xml/dom/xmltext.dart
@@ -88,7 +88,7 @@ class XmlText extends IInspectable
   IXmlNode? get parentNode => _iXmlNode.parentNode;
 
   @override
-  XmlNodeList get childNodes => _iXmlNode.childNodes;
+  XmlNodeList? get childNodes => _iXmlNode.childNodes;
 
   @override
   IXmlNode? get firstChild => _iXmlNode.firstChild;
@@ -103,7 +103,7 @@ class XmlText extends IInspectable
   IXmlNode? get nextSibling => _iXmlNode.nextSibling;
 
   @override
-  XmlNamedNodeMap get attributes => _iXmlNode.attributes;
+  XmlNamedNodeMap? get attributes => _iXmlNode.attributes;
 
   @override
   bool hasChildNodes() => _iXmlNode.hasChildNodes();

--- a/packages/windows_devices/lib/src/enumeration/deviceinformation.dart
+++ b/packages/windows_devices/lib/src/enumeration/deviceinformation.dart
@@ -150,7 +150,7 @@ class DeviceInformation extends IInspectable
       _iDeviceInformation.enclosureLocation;
 
   @override
-  Map<String, Object?> get properties => _iDeviceInformation.properties;
+  Map<String, Object?>? get properties => _iDeviceInformation.properties;
 
   @override
   void update(DeviceInformationUpdate? updateInfo) =>

--- a/packages/windows_devices/lib/src/enumeration/deviceinformationupdate.dart
+++ b/packages/windows_devices/lib/src/enumeration/deviceinformationupdate.dart
@@ -30,7 +30,7 @@ class DeviceInformationUpdate extends IInspectable
   String get id => _iDeviceInformationUpdate.id;
 
   @override
-  Map<String, Object?> get properties => _iDeviceInformationUpdate.properties;
+  Map<String, Object?>? get properties => _iDeviceInformationUpdate.properties;
 
   late final _iDeviceInformationUpdate2 = IDeviceInformationUpdate2.from(this);
 

--- a/packages/windows_devices/lib/src/enumeration/devicepicker.dart
+++ b/packages/windows_devices/lib/src/enumeration/devicepicker.dart
@@ -39,7 +39,8 @@ class DevicePicker extends IInspectable implements IDevicePicker {
   DevicePickerAppearance? get appearance => _iDevicePicker.appearance;
 
   @override
-  IVector<String> get requestedProperties => _iDevicePicker.requestedProperties;
+  IVector<String>? get requestedProperties =>
+      _iDevicePicker.requestedProperties;
 
   @override
   int add_DeviceSelected(Pointer<COMObject> handler) =>

--- a/packages/windows_devices/lib/src/enumeration/devicepickerfilter.dart
+++ b/packages/windows_devices/lib/src/enumeration/devicepickerfilter.dart
@@ -27,10 +27,10 @@ class DevicePickerFilter extends IInspectable implements IDevicePickerFilter {
   late final _iDevicePickerFilter = IDevicePickerFilter.from(this);
 
   @override
-  IVector<DeviceClass> get supportedDeviceClasses =>
+  IVector<DeviceClass>? get supportedDeviceClasses =>
       _iDevicePickerFilter.supportedDeviceClasses;
 
   @override
-  IVector<String> get supportedDeviceSelectors =>
+  IVector<String>? get supportedDeviceSelectors =>
       _iDevicePickerFilter.supportedDeviceSelectors;
 }

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformation.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformation.dart
@@ -155,7 +155,7 @@ class IDeviceInformation extends IInspectable {
     return EnclosureLocation.fromPtr(value);
   }
 
-  Map<String, Object?> get properties {
+  Map<String, Object?>? get properties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -173,6 +173,11 @@ class IDeviceInformation extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMapView<String, Object?>.fromPtr(value,

--- a/packages/windows_devices/lib/src/enumeration/ideviceinformationupdate.dart
+++ b/packages/windows_devices/lib/src/enumeration/ideviceinformationupdate.dart
@@ -51,7 +51,7 @@ class IDeviceInformationUpdate extends IInspectable {
     }
   }
 
-  Map<String, Object?> get properties {
+  Map<String, Object?>? get properties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -69,6 +69,11 @@ class IDeviceInformationUpdate extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMapView<String, Object?>.fromPtr(value,

--- a/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicepicker.dart
@@ -88,7 +88,7 @@ class IDevicePicker extends IInspectable {
     return DevicePickerAppearance.fromPtr(value);
   }
 
-  IVector<String> get requestedProperties {
+  IVector<String>? get requestedProperties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -106,6 +106,11 @@ class IDevicePicker extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_devices/lib/src/enumeration/idevicepickerfilter.dart
+++ b/packages/windows_devices/lib/src/enumeration/idevicepickerfilter.dart
@@ -28,7 +28,7 @@ class IDevicePickerFilter extends IInspectable {
       IDevicePickerFilter.fromPtr(
           interface.toInterface(IID_IDevicePickerFilter));
 
-  IVector<DeviceClass> get supportedDeviceClasses {
+  IVector<DeviceClass>? get supportedDeviceClasses {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -48,12 +48,17 @@ class IDevicePickerFilter extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IVector.fromPtr(value,
         iterableIid: '{47d4be05-58f1-522e-81c6-975eb4131bb9}',
         enumCreator: DeviceClass.from);
   }
 
-  IVector<String> get supportedDeviceSelectors {
+  IVector<String>? get supportedDeviceSelectors {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -71,6 +76,11 @@ class IDevicePickerFilter extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_devices/test/collections_test.dart
+++ b/packages/windows_devices/test/collections_test.dart
@@ -22,7 +22,7 @@ void main() {
     IVector<DeviceClass> getVector() {
       final picker = DevicePicker();
       final pickerFilter = picker.filter!;
-      return pickerFilter.supportedDeviceClasses;
+      return pickerFilter.supportedDeviceClasses!;
     }
 
     test('getAt fails if the vector is empty', () {

--- a/packages/windows_foundation/lib/src/iuriruntimeclass.dart
+++ b/packages/windows_foundation/lib/src/iuriruntimeclass.dart
@@ -254,7 +254,7 @@ class IUriRuntimeClass extends IInspectable {
     }
   }
 
-  WwwFormUrlDecoder get queryParsed {
+  WwwFormUrlDecoder? get queryParsed {
     final ppWwwFormUrlDecoder = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -273,6 +273,11 @@ class IUriRuntimeClass extends IInspectable {
     if (FAILED(hr)) {
       free(ppWwwFormUrlDecoder);
       throwWindowsException(hr);
+    }
+
+    if (ppWwwFormUrlDecoder.isNull) {
+      free(ppWwwFormUrlDecoder);
+      return null;
     }
 
     return WwwFormUrlDecoder.fromPtr(ppWwwFormUrlDecoder);

--- a/packages/windows_foundation/lib/src/uri.dart
+++ b/packages/windows_foundation/lib/src/uri.dart
@@ -85,7 +85,7 @@ class Uri extends IInspectable
   String get query => _iUriRuntimeClass.query;
 
   @override
-  WwwFormUrlDecoder get queryParsed => _iUriRuntimeClass.queryParsed;
+  WwwFormUrlDecoder? get queryParsed => _iUriRuntimeClass.queryParsed;
 
   @override
   String get rawUri => _iUriRuntimeClass.rawUri;

--- a/packages/windows_foundation/test/uri_test.dart
+++ b/packages/windows_foundation/test/uri_test.dart
@@ -34,15 +34,18 @@ void main() {
     expect(winrtUri.extension, equals('.html'));
     expect(winrtUri.query, equals('?q1=v1&q2=v2'));
     final queryParsed = winrtUri.queryParsed;
-    expect(queryParsed.size, equals(2));
+    expect(queryParsed, isNotNull);
+    expect(queryParsed!.size, equals(2));
     final queryParameters = queryParsed.toList();
     expect(queryParameters.length, equals(2));
     final firstQueryParam = queryParameters.first;
-    expect(firstQueryParam?.name, equals('q1'));
-    expect(firstQueryParam?.value, equals('v1'));
+    expect(firstQueryParam, isNotNull);
+    expect(firstQueryParam!.name, equals('q1'));
+    expect(firstQueryParam.value, equals('v1'));
     final lastQueryParam = queryParameters.last;
-    expect(lastQueryParam?.name, equals('q2'));
-    expect(lastQueryParam?.value, equals('v2'));
+    expect(lastQueryParam, isNotNull);
+    expect(lastQueryParam!.name, equals('q2'));
+    expect(lastQueryParam.value, equals('v2'));
     expect(winrtUri.fragment, equals('#fragment'));
   });
 }

--- a/packages/windows_gaming/lib/src/input/gamepad.dart
+++ b/packages/windows_gaming/lib/src/input/gamepad.dart
@@ -58,7 +58,7 @@ class Gamepad extends IInspectable
           IGamepadStatics.fromPtr, _className, IID_IGamepadStatics)
       .remove_GamepadRemoved(token);
 
-  static List<Gamepad?> get gamepads => createActivationFactory(
+  static List<Gamepad?>? get gamepads => createActivationFactory(
           IGamepadStatics.fromPtr, _className, IID_IGamepadStatics)
       .gamepads;
 

--- a/packages/windows_gaming/lib/src/input/igamepadstatics.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics.dart
@@ -109,7 +109,7 @@ class IGamepadStatics extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  List<Gamepad?> get gamepads {
+  List<Gamepad?>? get gamepads {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -127,6 +127,11 @@ class IGamepadStatics extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<Gamepad?>.fromPtr(value,

--- a/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
+++ b/packages/windows_gaming/lib/src/input/igamepadstatics2.dart
@@ -79,5 +79,5 @@ class IGamepadStatics2 extends IInspectable implements IGamepadStatics {
       _iGamepadStatics.remove_GamepadRemoved(token);
 
   @override
-  List<Gamepad?> get gamepads => _iGamepadStatics.gamepads;
+  List<Gamepad?>? get gamepads => _iGamepadStatics.gamepads;
 }

--- a/packages/windows_globalization/lib/src/calendar.dart
+++ b/packages/windows_globalization/lib/src/calendar.dart
@@ -59,7 +59,7 @@ class Calendar extends IInspectable implements ICalendar, ITimeZoneOnCalendar {
   void setToMax() => _iCalendar.setToMax();
 
   @override
-  List<String> get languages => _iCalendar.languages;
+  List<String>? get languages => _iCalendar.languages;
 
   @override
   String get numeralSystem => _iCalendar.numeralSystem;

--- a/packages/windows_globalization/lib/src/datetimeformatting/datetimeformatter.dart
+++ b/packages/windows_globalization/lib/src/datetimeformatting/datetimeformatter.dart
@@ -148,7 +148,7 @@ class DateTimeFormatter extends IInspectable
   late final _iDateTimeFormatter = IDateTimeFormatter.from(this);
 
   @override
-  List<String> get languages => _iDateTimeFormatter.languages;
+  List<String>? get languages => _iDateTimeFormatter.languages;
 
   @override
   String get geographicRegion => _iDateTimeFormatter.geographicRegion;
@@ -166,7 +166,7 @@ class DateTimeFormatter extends IInspectable
   set numeralSystem(String value) => _iDateTimeFormatter.numeralSystem = value;
 
   @override
-  List<String> get patterns => _iDateTimeFormatter.patterns;
+  List<String>? get patterns => _iDateTimeFormatter.patterns;
 
   @override
   String get template => _iDateTimeFormatter.template;

--- a/packages/windows_globalization/lib/src/datetimeformatting/idatetimeformatter.dart
+++ b/packages/windows_globalization/lib/src/datetimeformatting/idatetimeformatter.dart
@@ -33,7 +33,7 @@ class IDateTimeFormatter extends IInspectable {
   factory IDateTimeFormatter.from(IInspectable interface) =>
       IDateTimeFormatter.fromPtr(interface.toInterface(IID_IDateTimeFormatter));
 
-  List<String> get languages {
+  List<String>? get languages {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -51,6 +51,11 @@ class IDateTimeFormatter extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,
@@ -178,7 +183,7 @@ class IDateTimeFormatter extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  List<String> get patterns {
+  List<String>? get patterns {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -196,6 +201,11 @@ class IDateTimeFormatter extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_globalization/lib/src/geographicregion.dart
+++ b/packages/windows_globalization/lib/src/geographicregion.dart
@@ -58,5 +58,5 @@ class GeographicRegion extends IInspectable implements IGeographicRegion {
   String get nativeName => _iGeographicRegion.nativeName;
 
   @override
-  List<String> get currenciesInUse => _iGeographicRegion.currenciesInUse;
+  List<String>? get currenciesInUse => _iGeographicRegion.currenciesInUse;
 }

--- a/packages/windows_globalization/lib/src/icalendar.dart
+++ b/packages/windows_globalization/lib/src/icalendar.dart
@@ -76,7 +76,7 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  List<String> get languages {
+  List<String>? get languages {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -94,6 +94,11 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_globalization/lib/src/igeographicregion.dart
+++ b/packages/windows_globalization/lib/src/igeographicregion.dart
@@ -175,7 +175,7 @@ class IGeographicRegion extends IInspectable {
     }
   }
 
-  List<String> get currenciesInUse {
+  List<String>? get currenciesInUse {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -193,6 +193,11 @@ class IGeographicRegion extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_globalization/lib/src/numberformatting/currencyformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/currencyformatter.dart
@@ -93,7 +93,7 @@ class CurrencyFormatter extends IInspectable
   late final _iNumberFormatterOptions = INumberFormatterOptions.from(this);
 
   @override
-  List<String> get languages => _iNumberFormatterOptions.languages;
+  List<String>? get languages => _iNumberFormatterOptions.languages;
 
   @override
   String get geographicRegion => _iNumberFormatterOptions.geographicRegion;

--- a/packages/windows_globalization/lib/src/numberformatting/decimalformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/decimalformatter.dart
@@ -48,7 +48,7 @@ class DecimalFormatter extends IInspectable
   late final _iNumberFormatterOptions = INumberFormatterOptions.from(this);
 
   @override
-  List<String> get languages => _iNumberFormatterOptions.languages;
+  List<String>? get languages => _iNumberFormatterOptions.languages;
 
   @override
   String get geographicRegion => _iNumberFormatterOptions.geographicRegion;

--- a/packages/windows_globalization/lib/src/numberformatting/icurrencyformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/icurrencyformatter.dart
@@ -80,7 +80,7 @@ class ICurrencyFormatter extends IInspectable
   late final _iNumberFormatterOptions = INumberFormatterOptions.from(this);
 
   @override
-  List<String> get languages => _iNumberFormatterOptions.languages;
+  List<String>? get languages => _iNumberFormatterOptions.languages;
 
   @override
   String get geographicRegion => _iNumberFormatterOptions.geographicRegion;

--- a/packages/windows_globalization/lib/src/numberformatting/inumberformatteroptions.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/inumberformatteroptions.dart
@@ -26,7 +26,7 @@ class INumberFormatterOptions extends IInspectable {
       INumberFormatterOptions.fromPtr(
           interface.toInterface(IID_INumberFormatterOptions));
 
-  List<String> get languages {
+  List<String>? get languages {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -44,6 +44,11 @@ class INumberFormatterOptions extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_globalization/lib/src/numberformatting/inumeralsystemtranslator.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/inumeralsystemtranslator.dart
@@ -26,7 +26,7 @@ class INumeralSystemTranslator extends IInspectable {
       INumeralSystemTranslator.fromPtr(
           interface.toInterface(IID_INumeralSystemTranslator));
 
-  List<String> get languages {
+  List<String>? get languages {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -44,6 +44,11 @@ class INumeralSystemTranslator extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_globalization/lib/src/numberformatting/numeralsystemtranslator.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/numeralsystemtranslator.dart
@@ -36,7 +36,7 @@ class NumeralSystemTranslator extends IInspectable
   late final _iNumeralSystemTranslator = INumeralSystemTranslator.from(this);
 
   @override
-  List<String> get languages => _iNumeralSystemTranslator.languages;
+  List<String>? get languages => _iNumeralSystemTranslator.languages;
 
   @override
   String get resolvedLanguage => _iNumeralSystemTranslator.resolvedLanguage;

--- a/packages/windows_globalization/lib/src/numberformatting/percentformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/percentformatter.dart
@@ -48,7 +48,7 @@ class PercentFormatter extends IInspectable
   late final _iNumberFormatterOptions = INumberFormatterOptions.from(this);
 
   @override
-  List<String> get languages => _iNumberFormatterOptions.languages;
+  List<String>? get languages => _iNumberFormatterOptions.languages;
 
   @override
   String get geographicRegion => _iNumberFormatterOptions.geographicRegion;

--- a/packages/windows_globalization/lib/src/numberformatting/permilleformatter.dart
+++ b/packages/windows_globalization/lib/src/numberformatting/permilleformatter.dart
@@ -48,7 +48,7 @@ class PermilleFormatter extends IInspectable
   late final _iNumberFormatterOptions = INumberFormatterOptions.from(this);
 
   @override
-  List<String> get languages => _iNumberFormatterOptions.languages;
+  List<String>? get languages => _iNumberFormatterOptions.languages;
 
   @override
   String get geographicRegion => _iNumberFormatterOptions.geographicRegion;

--- a/packages/windows_globalization/test/calendar_test.dart
+++ b/packages/windows_globalization/test/calendar_test.dart
@@ -49,8 +49,9 @@ void main() {
     test('languages', () {
       final calendar = Calendar();
       final languages = calendar.languages;
-      expect(languages.length, isPositive);
-      expect(languages.first, contains('-')); // e.g. en-US
+      expect(languages, isNotNull);
+      expect(languages?.length, isPositive);
+      expect(languages?.first, contains('-')); // e.g. en-US
     });
 
     test('numeralSystem getter', () {

--- a/packages/windows_graphics/lib/src/imaging/bitmapcodecinformation.dart
+++ b/packages/windows_graphics/lib/src/imaging/bitmapcodecinformation.dart
@@ -28,11 +28,11 @@ class BitmapCodecInformation extends IInspectable
   Guid get codecId => _iBitmapCodecInformation.codecId;
 
   @override
-  List<String> get fileExtensions => _iBitmapCodecInformation.fileExtensions;
+  List<String>? get fileExtensions => _iBitmapCodecInformation.fileExtensions;
 
   @override
   String get friendlyName => _iBitmapCodecInformation.friendlyName;
 
   @override
-  List<String> get mimeTypes => _iBitmapCodecInformation.mimeTypes;
+  List<String>? get mimeTypes => _iBitmapCodecInformation.mimeTypes;
 }

--- a/packages/windows_graphics/lib/src/imaging/ibitmapcodecinformation.dart
+++ b/packages/windows_graphics/lib/src/imaging/ibitmapcodecinformation.dart
@@ -50,7 +50,7 @@ class IBitmapCodecInformation extends IInspectable {
     }
   }
 
-  List<String> get fileExtensions {
+  List<String>? get fileExtensions {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -68,6 +68,11 @@ class IBitmapCodecInformation extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,
@@ -100,7 +105,7 @@ class IBitmapCodecInformation extends IInspectable {
     }
   }
 
-  List<String> get mimeTypes {
+  List<String>? get mimeTypes {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -118,6 +123,11 @@ class IBitmapCodecInformation extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_graphics/lib/src/printing3d/iprinting3dmultiplepropertymaterial.dart
+++ b/packages/windows_graphics/lib/src/printing3d/iprinting3dmultiplepropertymaterial.dart
@@ -27,7 +27,7 @@ class IPrinting3DMultiplePropertyMaterial extends IInspectable {
       IPrinting3DMultiplePropertyMaterial.fromPtr(
           interface.toInterface(IID_IPrinting3DMultiplePropertyMaterial));
 
-  IVector<int> get materialIndices {
+  IVector<int>? get materialIndices {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -45,6 +45,11 @@ class IPrinting3DMultiplePropertyMaterial extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_graphics/lib/src/printing3d/printing3dmultiplepropertymaterial.dart
+++ b/packages/windows_graphics/lib/src/printing3d/printing3dmultiplepropertymaterial.dart
@@ -31,6 +31,6 @@ class Printing3DMultiplePropertyMaterial extends IInspectable
       IPrinting3DMultiplePropertyMaterial.from(this);
 
   @override
-  IVector<int> get materialIndices =>
+  IVector<int>? get materialIndices =>
       _iPrinting3DMultiplePropertyMaterial.materialIndices;
 }

--- a/packages/windows_graphics/test/collections_test.dart
+++ b/packages/windows_graphics/test/collections_test.dart
@@ -21,7 +21,7 @@ void main() {
   group('IVector<int>', () {
     IVector<int> getVector() {
       final material = Printing3DMultiplePropertyMaterial();
-      return material.materialIndices;
+      return material.materialIndices!;
     }
 
     test('getAt fails if the vector is empty', () {

--- a/packages/windows_media/example/ocr.dart
+++ b/packages/windows_media/example/ocr.dart
@@ -9,7 +9,7 @@ import 'package:windows_storage/windows_storage.dart';
 
 Future<StorageFile> pickFile() async {
   final picker = FileOpenPicker()
-    ..fileTypeFilter.replaceAll(['.bmp', '.jpg', '.jpeg', '.png'])
+    ..fileTypeFilter?.replaceAll(['.bmp', '.jpg', '.jpeg', '.png'])
     ..suggestedStartLocation = PickerLocationId.desktop;
 
   InitializeWithWindow.initialize(picker);

--- a/packages/windows_media/lib/src/imediaframe.dart
+++ b/packages/windows_media/lib/src/imediaframe.dart
@@ -250,7 +250,7 @@ class IMediaFrame extends IInspectable implements IClosable {
     }
   }
 
-  IPropertySet get extendedProperties {
+  IPropertySet? get extendedProperties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -268,6 +268,11 @@ class IMediaFrame extends IInspectable implements IClosable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IPropertySet.fromPtr(value);

--- a/packages/windows_media/lib/src/ivideoframe.dart
+++ b/packages/windows_media/lib/src/ivideoframe.dart
@@ -143,7 +143,7 @@ class IVideoFrame extends IInspectable implements IMediaFrame, IClosable {
   bool get isDiscontinuous => _iMediaFrame.isDiscontinuous;
 
   @override
-  IPropertySet get extendedProperties => _iMediaFrame.extendedProperties;
+  IPropertySet? get extendedProperties => _iMediaFrame.extendedProperties;
 
   late final _iClosable = IClosable.from(this);
 

--- a/packages/windows_media/lib/src/ocr/iocrenginestatics.dart
+++ b/packages/windows_media/lib/src/ocr/iocrenginestatics.dart
@@ -52,7 +52,7 @@ class IOcrEngineStatics extends IInspectable {
     }
   }
 
-  List<Language?> get availableRecognizerLanguages {
+  List<Language?>? get availableRecognizerLanguages {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -70,6 +70,11 @@ class IOcrEngineStatics extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<Language?>.fromPtr(value,

--- a/packages/windows_media/lib/src/ocr/iocrline.dart
+++ b/packages/windows_media/lib/src/ocr/iocrline.dart
@@ -27,7 +27,7 @@ class IOcrLine extends IInspectable {
   factory IOcrLine.from(IInspectable interface) =>
       IOcrLine.fromPtr(interface.toInterface(IID_IOcrLine));
 
-  List<OcrWord?> get words {
+  List<OcrWord?>? get words {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -45,6 +45,11 @@ class IOcrLine extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<OcrWord?>.fromPtr(value,

--- a/packages/windows_media/lib/src/ocr/iocrresult.dart
+++ b/packages/windows_media/lib/src/ocr/iocrresult.dart
@@ -27,7 +27,7 @@ class IOcrResult extends IInspectable {
   factory IOcrResult.from(IInspectable interface) =>
       IOcrResult.fromPtr(interface.toInterface(IID_IOcrResult));
 
-  List<OcrLine?> get lines {
+  List<OcrLine?>? get lines {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -45,6 +45,11 @@ class IOcrResult extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<OcrLine?>.fromPtr(value,

--- a/packages/windows_media/lib/src/ocr/ocrengine.dart
+++ b/packages/windows_media/lib/src/ocr/ocrengine.dart
@@ -31,7 +31,7 @@ class OcrEngine extends IInspectable implements IOcrEngine {
           IOcrEngineStatics.fromPtr, _className, IID_IOcrEngineStatics)
       .maxImageDimension;
 
-  static List<Language?> get availableRecognizerLanguages =>
+  static List<Language?>? get availableRecognizerLanguages =>
       createActivationFactory(
               IOcrEngineStatics.fromPtr, _className, IID_IOcrEngineStatics)
           .availableRecognizerLanguages;

--- a/packages/windows_media/lib/src/ocr/ocrline.dart
+++ b/packages/windows_media/lib/src/ocr/ocrline.dart
@@ -26,7 +26,7 @@ class OcrLine extends IInspectable implements IOcrLine {
   late final _iOcrLine = IOcrLine.from(this);
 
   @override
-  List<OcrWord?> get words => _iOcrLine.words;
+  List<OcrWord?>? get words => _iOcrLine.words;
 
   @override
   String get text => _iOcrLine.text;

--- a/packages/windows_media/lib/src/ocr/ocrresult.dart
+++ b/packages/windows_media/lib/src/ocr/ocrresult.dart
@@ -25,7 +25,7 @@ class OcrResult extends IInspectable implements IOcrResult {
   late final _iOcrResult = IOcrResult.from(this);
 
   @override
-  List<OcrLine?> get lines => _iOcrResult.lines;
+  List<OcrLine?>? get lines => _iOcrResult.lines;
 
   @override
   double? get textAngle => _iOcrResult.textAngle;

--- a/packages/windows_media/lib/src/videoframe.dart
+++ b/packages/windows_media/lib/src/videoframe.dart
@@ -112,7 +112,7 @@ class VideoFrame extends IInspectable
   bool get isDiscontinuous => _iMediaFrame.isDiscontinuous;
 
   @override
-  IPropertySet get extendedProperties => _iMediaFrame.extendedProperties;
+  IPropertySet? get extendedProperties => _iMediaFrame.extendedProperties;
 
   late final _iClosable = IClosable.from(this);
 

--- a/packages/windows_networking/lib/src/connectivity/ilanidentifierdata.dart
+++ b/packages/windows_networking/lib/src/connectivity/ilanidentifierdata.dart
@@ -49,7 +49,7 @@ class ILanIdentifierData extends IInspectable {
     }
   }
 
-  List<int> get value {
+  List<int>? get value {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -67,6 +67,11 @@ class ILanIdentifierData extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<int>.fromPtr(value,

--- a/packages/windows_networking/lib/src/connectivity/iproxyconfiguration.dart
+++ b/packages/windows_networking/lib/src/connectivity/iproxyconfiguration.dart
@@ -26,7 +26,7 @@ class IProxyConfiguration extends IInspectable {
       IProxyConfiguration.fromPtr(
           interface.toInterface(IID_IProxyConfiguration));
 
-  List<Uri?> get proxyUris {
+  List<Uri?>? get proxyUris {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -44,6 +44,11 @@ class IProxyConfiguration extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<Uri?>.fromPtr(value,

--- a/packages/windows_networking/lib/src/connectivity/iwwanconnectionprofiledetails2.dart
+++ b/packages/windows_networking/lib/src/connectivity/iwwanconnectionprofiledetails2.dart
@@ -53,7 +53,7 @@ class IWwanConnectionProfileDetails2 extends IInspectable {
     }
   }
 
-  List<Guid> get purposeGuids {
+  List<Guid>? get purposeGuids {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -71,6 +71,11 @@ class IWwanConnectionProfileDetails2 extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<Guid>.fromPtr(value,

--- a/packages/windows_networking/lib/src/connectivity/lanidentifierdata.dart
+++ b/packages/windows_networking/lib/src/connectivity/lanidentifierdata.dart
@@ -28,5 +28,5 @@ class LanIdentifierData extends IInspectable implements ILanIdentifierData {
   int get type => _iLanIdentifierData.type;
 
   @override
-  List<int> get value => _iLanIdentifierData.value;
+  List<int>? get value => _iLanIdentifierData.value;
 }

--- a/packages/windows_networking/lib/src/connectivity/proxyconfiguration.dart
+++ b/packages/windows_networking/lib/src/connectivity/proxyconfiguration.dart
@@ -24,7 +24,7 @@ class ProxyConfiguration extends IInspectable implements IProxyConfiguration {
   late final _iProxyConfiguration = IProxyConfiguration.from(this);
 
   @override
-  List<Uri?> get proxyUris => _iProxyConfiguration.proxyUris;
+  List<Uri?>? get proxyUris => _iProxyConfiguration.proxyUris;
 
   @override
   bool get canConnectDirectly => _iProxyConfiguration.canConnectDirectly;

--- a/packages/windows_networking/lib/src/connectivity/wwanconnectionprofiledetails.dart
+++ b/packages/windows_networking/lib/src/connectivity/wwanconnectionprofiledetails.dart
@@ -50,5 +50,5 @@ class WwanConnectionProfileDetails extends IInspectable
   WwanNetworkIPKind get ipKind => _iWwanConnectionProfileDetails2.ipKind;
 
   @override
-  List<Guid> get purposeGuids => _iWwanConnectionProfileDetails2.purposeGuids;
+  List<Guid>? get purposeGuids => _iWwanConnectionProfileDetails2.purposeGuids;
 }

--- a/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringclient.dart
+++ b/packages/windows_networking/lib/src/networkoperators/inetworkoperatortetheringclient.dart
@@ -54,7 +54,7 @@ class INetworkOperatorTetheringClient extends IInspectable {
     }
   }
 
-  List<HostName?> get hostNames {
+  List<HostName?>? get hostNames {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -72,6 +72,11 @@ class INetworkOperatorTetheringClient extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<HostName?>.fromPtr(value,

--- a/packages/windows_networking/lib/src/networkoperators/networkoperatortetheringclient.dart
+++ b/packages/windows_networking/lib/src/networkoperators/networkoperatortetheringclient.dart
@@ -30,5 +30,5 @@ class NetworkOperatorTetheringClient extends IInspectable
   String get macAddress => _iNetworkOperatorTetheringClient.macAddress;
 
   @override
-  List<HostName?> get hostNames => _iNetworkOperatorTetheringClient.hostNames;
+  List<HostName?>? get hostNames => _iNetworkOperatorTetheringClient.hostNames;
 }

--- a/packages/windows_security/lib/src/authentication/web/core/findallaccountsresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/findallaccountsresult.dart
@@ -28,7 +28,7 @@ class FindAllAccountsResult extends IInspectable
   late final _iFindAllAccountsResult = IFindAllAccountsResult.from(this);
 
   @override
-  List<WebAccount?> get accounts => _iFindAllAccountsResult.accounts;
+  List<WebAccount?>? get accounts => _iFindAllAccountsResult.accounts;
 
   @override
   FindAllWebAccountsStatus get status => _iFindAllAccountsResult.status;

--- a/packages/windows_security/lib/src/authentication/web/core/ifindallaccountsresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/ifindallaccountsresult.dart
@@ -30,7 +30,7 @@ class IFindAllAccountsResult extends IInspectable {
       IFindAllAccountsResult.fromPtr(
           interface.toInterface(IID_IFindAllAccountsResult));
 
-  List<WebAccount?> get accounts {
+  List<WebAccount?>? get accounts {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -48,6 +48,11 @@ class IFindAllAccountsResult extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<WebAccount?>.fromPtr(value,

--- a/packages/windows_security/lib/src/authentication/web/core/iwebprovidererror.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebprovidererror.dart
@@ -74,7 +74,7 @@ class IWebProviderError extends IInspectable {
     }
   }
 
-  IMap<String, String> get properties {
+  IMap<String, String>? get properties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -92,6 +92,11 @@ class IWebProviderError extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMap.fromPtr(value,

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequest.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequest.dart
@@ -130,7 +130,7 @@ class IWebTokenRequest extends IInspectable {
     }
   }
 
-  IMap<String, String> get properties {
+  IMap<String, String>? get properties {
     final requestProperties = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -149,6 +149,11 @@ class IWebTokenRequest extends IInspectable {
     if (FAILED(hr)) {
       free(requestProperties);
       throwWindowsException(hr);
+    }
+
+    if (requestProperties.isNull) {
+      free(requestProperties);
+      return null;
     }
 
     return IMap.fromPtr(requestProperties,

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequest2.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequest2.dart
@@ -25,7 +25,7 @@ class IWebTokenRequest2 extends IInspectable {
   factory IWebTokenRequest2.from(IInspectable interface) =>
       IWebTokenRequest2.fromPtr(interface.toInterface(IID_IWebTokenRequest2));
 
-  IMap<String, String> get appProperties {
+  IMap<String, String>? get appProperties {
     final requestProperties = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -44,6 +44,11 @@ class IWebTokenRequest2 extends IInspectable {
     if (FAILED(hr)) {
       free(requestProperties);
       throwWindowsException(hr);
+    }
+
+    if (requestProperties.isNull) {
+      free(requestProperties);
+      return null;
     }
 
     return IMap.fromPtr(requestProperties,

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequestresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenrequestresult.dart
@@ -30,7 +30,7 @@ class IWebTokenRequestResult extends IInspectable {
       IWebTokenRequestResult.fromPtr(
           interface.toInterface(IID_IWebTokenRequestResult));
 
-  List<WebTokenResponse?> get responseData {
+  List<WebTokenResponse?>? get responseData {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -48,6 +48,11 @@ class IWebTokenRequestResult extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<WebTokenResponse?>.fromPtr(value,

--- a/packages/windows_security/lib/src/authentication/web/core/iwebtokenresponse.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/iwebtokenresponse.dart
@@ -109,7 +109,7 @@ class IWebTokenResponse extends IInspectable {
     return WebAccount.fromPtr(value);
   }
 
-  IMap<String, String> get properties {
+  IMap<String, String>? get properties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -127,6 +127,11 @@ class IWebTokenResponse extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMap.fromPtr(value,

--- a/packages/windows_security/lib/src/authentication/web/core/webprovidererror.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webprovidererror.dart
@@ -39,5 +39,5 @@ class WebProviderError extends IInspectable implements IWebProviderError {
   String get errorMessage => _iWebProviderError.errorMessage;
 
   @override
-  IMap<String, String> get properties => _iWebProviderError.properties;
+  IMap<String, String>? get properties => _iWebProviderError.properties;
 }

--- a/packages/windows_security/lib/src/authentication/web/core/webtokenrequest.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webtokenrequest.dart
@@ -73,12 +73,12 @@ class WebTokenRequest extends IInspectable
   WebTokenRequestPromptType get promptType => _iWebTokenRequest.promptType;
 
   @override
-  IMap<String, String> get properties => _iWebTokenRequest.properties;
+  IMap<String, String>? get properties => _iWebTokenRequest.properties;
 
   late final _iWebTokenRequest2 = IWebTokenRequest2.from(this);
 
   @override
-  IMap<String, String> get appProperties => _iWebTokenRequest2.appProperties;
+  IMap<String, String>? get appProperties => _iWebTokenRequest2.appProperties;
 
   late final _iWebTokenRequest3 = IWebTokenRequest3.from(this);
 

--- a/packages/windows_security/lib/src/authentication/web/core/webtokenrequestresult.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webtokenrequestresult.dart
@@ -28,7 +28,7 @@ class WebTokenRequestResult extends IInspectable
   late final _iWebTokenRequestResult = IWebTokenRequestResult.from(this);
 
   @override
-  List<WebTokenResponse?> get responseData =>
+  List<WebTokenResponse?>? get responseData =>
       _iWebTokenRequestResult.responseData;
 
   @override

--- a/packages/windows_security/lib/src/authentication/web/core/webtokenresponse.dart
+++ b/packages/windows_security/lib/src/authentication/web/core/webtokenresponse.dart
@@ -58,5 +58,5 @@ class WebTokenResponse extends IInspectable implements IWebTokenResponse {
   WebAccount? get webAccount => _iWebTokenResponse.webAccount;
 
   @override
-  IMap<String, String> get properties => _iWebTokenResponse.properties;
+  IMap<String, String>? get properties => _iWebTokenResponse.properties;
 }

--- a/packages/windows_security/lib/src/credentials/iwebaccount2.dart
+++ b/packages/windows_security/lib/src/credentials/iwebaccount2.dart
@@ -56,7 +56,7 @@ class IWebAccount2 extends IInspectable implements IWebAccount {
     }
   }
 
-  Map<String, String> get properties {
+  Map<String, String>? get properties {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -74,6 +74,11 @@ class IWebAccount2 extends IInspectable implements IWebAccount {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMapView<String, String>.fromPtr(value,

--- a/packages/windows_security/lib/src/credentials/webaccount.dart
+++ b/packages/windows_security/lib/src/credentials/webaccount.dart
@@ -52,7 +52,7 @@ class WebAccount extends IInspectable implements IWebAccount, IWebAccount2 {
   String get id => _iWebAccount2.id;
 
   @override
-  Map<String, String> get properties => _iWebAccount2.properties;
+  Map<String, String>? get properties => _iWebAccount2.properties;
 
   @override
   Future<IRandomAccessStream?> getPictureAsync(

--- a/packages/windows_storage/example/picker.dart
+++ b/packages/windows_storage/example/picker.dart
@@ -20,7 +20,7 @@ void printFileInformation(StorageFile? file) {
 
 void main() async {
   final picker = FileOpenPicker()
-    ..fileTypeFilter.append('*') // Allow all file types
+    ..fileTypeFilter?.append('*') // Allow all file types
     ..suggestedStartLocation = PickerLocationId.desktop
     ..viewMode = PickerViewMode.thumbnail;
 

--- a/packages/windows_storage/lib/src/applicationdatacontainer.dart
+++ b/packages/windows_storage/lib/src/applicationdatacontainer.dart
@@ -35,10 +35,10 @@ class ApplicationDataContainer extends IInspectable
   ApplicationDataLocality get locality => _iApplicationDataContainer.locality;
 
   @override
-  IPropertySet get values => _iApplicationDataContainer.values;
+  IPropertySet? get values => _iApplicationDataContainer.values;
 
   @override
-  Map<String, ApplicationDataContainer?> get containers =>
+  Map<String, ApplicationDataContainer?>? get containers =>
       _iApplicationDataContainer.containers;
 
   @override

--- a/packages/windows_storage/lib/src/fileproperties/documentproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/documentproperties.dart
@@ -27,7 +27,7 @@ class DocumentProperties extends IInspectable
   late final _iDocumentProperties = IDocumentProperties.from(this);
 
   @override
-  IVector<String> get author => _iDocumentProperties.author;
+  IVector<String>? get author => _iDocumentProperties.author;
 
   @override
   String get title => _iDocumentProperties.title;
@@ -36,7 +36,7 @@ class DocumentProperties extends IInspectable
   set title(String value) => _iDocumentProperties.title = value;
 
   @override
-  IVector<String> get keywords => _iDocumentProperties.keywords;
+  IVector<String>? get keywords => _iDocumentProperties.keywords;
 
   @override
   String get comment => _iDocumentProperties.comment;

--- a/packages/windows_storage/lib/src/fileproperties/idocumentproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/idocumentproperties.dart
@@ -29,7 +29,7 @@ class IDocumentProperties extends IInspectable
       IDocumentProperties.fromPtr(
           interface.toInterface(IID_IDocumentProperties));
 
-  IVector<String> get author {
+  IVector<String>? get author {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -47,6 +47,11 @@ class IDocumentProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -98,7 +103,7 @@ class IDocumentProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get keywords {
+  IVector<String>? get keywords {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -116,6 +121,11 @@ class IDocumentProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/fileproperties/iimageproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/iimageproperties.dart
@@ -69,7 +69,7 @@ class IImageProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get keywords {
+  IVector<String>? get keywords {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -87,6 +87,11 @@ class IImageProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -398,7 +403,7 @@ class IImageProperties extends IInspectable
     }
   }
 
-  List<String> get peopleNames {
+  List<String>? get peopleNames {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -416,6 +421,11 @@ class IImageProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/windows_storage/lib/src/fileproperties/imageproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/imageproperties.dart
@@ -34,7 +34,7 @@ class ImageProperties extends IInspectable
   set rating(int value) => _iImageProperties.rating = value;
 
   @override
-  IVector<String> get keywords => _iImageProperties.keywords;
+  IVector<String>? get keywords => _iImageProperties.keywords;
 
   @override
   DateTime get dateTaken => _iImageProperties.dateTaken;
@@ -77,7 +77,7 @@ class ImageProperties extends IInspectable
   PhotoOrientation get orientation => _iImageProperties.orientation;
 
   @override
-  List<String> get peopleNames => _iImageProperties.peopleNames;
+  List<String>? get peopleNames => _iImageProperties.peopleNames;
 
   late final _iStorageItemExtraProperties =
       IStorageItemExtraProperties.from(this);

--- a/packages/windows_storage/lib/src/fileproperties/imusicproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/imusicproperties.dart
@@ -118,7 +118,7 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get genre {
+  IVector<String>? get genre {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -136,6 +136,11 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -360,7 +365,7 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get composers {
+  IVector<String>? get composers {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -380,11 +385,16 @@ class IMusicProperties extends IInspectable
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IVector.fromPtr(value,
         iterableIid: '{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}');
   }
 
-  IVector<String> get conductors {
+  IVector<String>? get conductors {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -402,6 +412,11 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -453,7 +468,7 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get producers {
+  IVector<String>? get producers {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -471,6 +486,11 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -522,7 +542,7 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get writers {
+  IVector<String>? get writers {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -540,6 +560,11 @@ class IMusicProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/fileproperties/ivideoproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/ivideoproperties.dart
@@ -69,7 +69,7 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get keywords {
+  IVector<String>? get keywords {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -87,6 +87,11 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -315,7 +320,7 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get producers {
+  IVector<String>? get producers {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -333,6 +338,11 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -384,7 +394,7 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get writers {
+  IVector<String>? get writers {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -402,6 +412,11 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -472,7 +487,7 @@ class IVideoProperties extends IInspectable
     }
   }
 
-  IVector<String> get directors {
+  IVector<String>? get directors {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -490,6 +505,11 @@ class IVideoProperties extends IInspectable
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/fileproperties/musicproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/musicproperties.dart
@@ -39,7 +39,7 @@ class MusicProperties extends IInspectable
   set artist(String value) => _iMusicProperties.artist = value;
 
   @override
-  IVector<String> get genre => _iMusicProperties.genre;
+  IVector<String>? get genre => _iMusicProperties.genre;
 
   @override
   int get trackNumber => _iMusicProperties.trackNumber;
@@ -72,10 +72,10 @@ class MusicProperties extends IInspectable
   set albumArtist(String value) => _iMusicProperties.albumArtist = value;
 
   @override
-  IVector<String> get composers => _iMusicProperties.composers;
+  IVector<String>? get composers => _iMusicProperties.composers;
 
   @override
-  IVector<String> get conductors => _iMusicProperties.conductors;
+  IVector<String>? get conductors => _iMusicProperties.conductors;
 
   @override
   String get subtitle => _iMusicProperties.subtitle;
@@ -84,7 +84,7 @@ class MusicProperties extends IInspectable
   set subtitle(String value) => _iMusicProperties.subtitle = value;
 
   @override
-  IVector<String> get producers => _iMusicProperties.producers;
+  IVector<String>? get producers => _iMusicProperties.producers;
 
   @override
   String get publisher => _iMusicProperties.publisher;
@@ -93,7 +93,7 @@ class MusicProperties extends IInspectable
   set publisher(String value) => _iMusicProperties.publisher = value;
 
   @override
-  IVector<String> get writers => _iMusicProperties.writers;
+  IVector<String>? get writers => _iMusicProperties.writers;
 
   @override
   int get year => _iMusicProperties.year;

--- a/packages/windows_storage/lib/src/fileproperties/videoproperties.dart
+++ b/packages/windows_storage/lib/src/fileproperties/videoproperties.dart
@@ -34,7 +34,7 @@ class VideoProperties extends IInspectable
   set rating(int value) => _iVideoProperties.rating = value;
 
   @override
-  IVector<String> get keywords => _iVideoProperties.keywords;
+  IVector<String>? get keywords => _iVideoProperties.keywords;
 
   @override
   int get width => _iVideoProperties.width;
@@ -64,7 +64,7 @@ class VideoProperties extends IInspectable
   set subtitle(String value) => _iVideoProperties.subtitle = value;
 
   @override
-  IVector<String> get producers => _iVideoProperties.producers;
+  IVector<String>? get producers => _iVideoProperties.producers;
 
   @override
   String get publisher => _iVideoProperties.publisher;
@@ -73,7 +73,7 @@ class VideoProperties extends IInspectable
   set publisher(String value) => _iVideoProperties.publisher = value;
 
   @override
-  IVector<String> get writers => _iVideoProperties.writers;
+  IVector<String>? get writers => _iVideoProperties.writers;
 
   @override
   int get year => _iVideoProperties.year;
@@ -85,7 +85,7 @@ class VideoProperties extends IInspectable
   int get bitrate => _iVideoProperties.bitrate;
 
   @override
-  IVector<String> get directors => _iVideoProperties.directors;
+  IVector<String>? get directors => _iVideoProperties.directors;
 
   @override
   VideoOrientation get orientation => _iVideoProperties.orientation;

--- a/packages/windows_storage/lib/src/iapplicationdatacontainer.dart
+++ b/packages/windows_storage/lib/src/iapplicationdatacontainer.dart
@@ -79,7 +79,7 @@ class IApplicationDataContainer extends IInspectable {
     }
   }
 
-  IPropertySet get values {
+  IPropertySet? get values {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -99,10 +99,15 @@ class IApplicationDataContainer extends IInspectable {
       throwWindowsException(hr);
     }
 
+    if (value.isNull) {
+      free(value);
+      return null;
+    }
+
     return IPropertySet.fromPtr(value);
   }
 
-  Map<String, ApplicationDataContainer?> get containers {
+  Map<String, ApplicationDataContainer?>? get containers {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -120,6 +125,11 @@ class IApplicationDataContainer extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMapView<String, ApplicationDataContainer?>.fromPtr(value,

--- a/packages/windows_storage/lib/src/pickers/fileopenpicker.dart
+++ b/packages/windows_storage/lib/src/pickers/fileopenpicker.dart
@@ -71,7 +71,7 @@ class FileOpenPicker extends IInspectable
       _iFileOpenPicker.commitButtonText = value;
 
   @override
-  IVector<String> get fileTypeFilter => _iFileOpenPicker.fileTypeFilter;
+  IVector<String>? get fileTypeFilter => _iFileOpenPicker.fileTypeFilter;
 
   @override
   Future<StorageFile?> pickSingleFileAsync() =>

--- a/packages/windows_storage/lib/src/pickers/filesavepicker.dart
+++ b/packages/windows_storage/lib/src/pickers/filesavepicker.dart
@@ -46,7 +46,7 @@ class FileSavePicker extends IInspectable
   late final _iFileSavePicker2 = IFileSavePicker2.from(this);
 
   @override
-  ValueSet get continuationData => _iFileSavePicker2.continuationData;
+  ValueSet? get continuationData => _iFileSavePicker2.continuationData;
 
   @Deprecated("Instead, use PickSaveFileAsync")
   @override
@@ -85,7 +85,7 @@ class FileSavePicker extends IInspectable
       _iFileSavePicker.commitButtonText = value;
 
   @override
-  IMap<String, IVector<String>> get fileTypeChoices =>
+  IMap<String, IVector<String>>? get fileTypeChoices =>
       _iFileSavePicker.fileTypeChoices;
 
   @override

--- a/packages/windows_storage/lib/src/pickers/folderpicker.dart
+++ b/packages/windows_storage/lib/src/pickers/folderpicker.dart
@@ -39,7 +39,7 @@ class FolderPicker extends IInspectable
   late final _iFolderPicker2 = IFolderPicker2.from(this);
 
   @override
-  ValueSet get continuationData => _iFolderPicker2.continuationData;
+  ValueSet? get continuationData => _iFolderPicker2.continuationData;
 
   @Deprecated("Instead, use PickSingleFolderAsync")
   @override
@@ -75,7 +75,7 @@ class FolderPicker extends IInspectable
   set commitButtonText(String value) => _iFolderPicker.commitButtonText = value;
 
   @override
-  IVector<String> get fileTypeFilter => _iFolderPicker.fileTypeFilter;
+  IVector<String>? get fileTypeFilter => _iFolderPicker.fileTypeFilter;
 
   @override
   Future<StorageFolder?> pickSingleFolderAsync() =>

--- a/packages/windows_storage/lib/src/pickers/ifileopenpicker.dart
+++ b/packages/windows_storage/lib/src/pickers/ifileopenpicker.dart
@@ -195,7 +195,7 @@ class IFileOpenPicker extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get fileTypeFilter {
+  IVector<String>? get fileTypeFilter {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -213,6 +213,11 @@ class IFileOpenPicker extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/pickers/ifilesavepicker.dart
+++ b/packages/windows_storage/lib/src/pickers/ifilesavepicker.dart
@@ -156,7 +156,7 @@ class IFileSavePicker extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IMap<String, IVector<String>> get fileTypeChoices {
+  IMap<String, IVector<String>>? get fileTypeChoices {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -174,6 +174,11 @@ class IFileSavePicker extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMap.fromPtr(value,

--- a/packages/windows_storage/lib/src/pickers/ifilesavepicker2.dart
+++ b/packages/windows_storage/lib/src/pickers/ifilesavepicker2.dart
@@ -25,7 +25,7 @@ class IFileSavePicker2 extends IInspectable {
   factory IFileSavePicker2.from(IInspectable interface) =>
       IFileSavePicker2.fromPtr(interface.toInterface(IID_IFileSavePicker2));
 
-  ValueSet get continuationData {
+  ValueSet? get continuationData {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -43,6 +43,11 @@ class IFileSavePicker2 extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return ValueSet.fromPtr(value);

--- a/packages/windows_storage/lib/src/pickers/ifolderpicker.dart
+++ b/packages/windows_storage/lib/src/pickers/ifolderpicker.dart
@@ -195,7 +195,7 @@ class IFolderPicker extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<String> get fileTypeFilter {
+  IVector<String>? get fileTypeFilter {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -213,6 +213,11 @@ class IFolderPicker extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/pickers/ifolderpicker2.dart
+++ b/packages/windows_storage/lib/src/pickers/ifolderpicker2.dart
@@ -25,7 +25,7 @@ class IFolderPicker2 extends IInspectable {
   factory IFolderPicker2.from(IInspectable interface) =>
       IFolderPicker2.fromPtr(interface.toInterface(IID_IFolderPicker2));
 
-  ValueSet get continuationData {
+  ValueSet? get continuationData {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -43,6 +43,11 @@ class IFolderPicker2 extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return ValueSet.fromPtr(value);

--- a/packages/windows_storage/lib/src/search/iqueryoptions.dart
+++ b/packages/windows_storage/lib/src/search/iqueryoptions.dart
@@ -33,7 +33,7 @@ class IQueryOptions extends IInspectable {
   factory IQueryOptions.from(IInspectable interface) =>
       IQueryOptions.fromPtr(interface.toInterface(IID_IQueryOptions));
 
-  IVector<String> get fileTypeFilter {
+  IVector<String>? get fileTypeFilter {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -51,6 +51,11 @@ class IQueryOptions extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,
@@ -268,7 +273,7 @@ class IQueryOptions extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<SortEntry> get sortOrder {
+  IVector<SortEntry>? get sortOrder {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -286,6 +291,11 @@ class IQueryOptions extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/search/iqueryoptionswithproviderfilter.dart
+++ b/packages/windows_storage/lib/src/search/iqueryoptionswithproviderfilter.dart
@@ -27,7 +27,7 @@ class IQueryOptionsWithProviderFilter extends IInspectable {
       IQueryOptionsWithProviderFilter.fromPtr(
           interface.toInterface(IID_IQueryOptionsWithProviderFilter));
 
-  IVector<String> get storageProviderIdFilter {
+  IVector<String>? get storageProviderIdFilter {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -45,6 +45,11 @@ class IQueryOptionsWithProviderFilter extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_storage/lib/src/search/queryoptions.dart
+++ b/packages/windows_storage/lib/src/search/queryoptions.dart
@@ -51,7 +51,7 @@ class QueryOptions extends IInspectable
   late final _iQueryOptions = IQueryOptions.from(this);
 
   @override
-  IVector<String> get fileTypeFilter => _iQueryOptions.fileTypeFilter;
+  IVector<String>? get fileTypeFilter => _iQueryOptions.fileTypeFilter;
 
   @override
   FolderDepth get folderDepth => _iQueryOptions.folderDepth;
@@ -86,7 +86,7 @@ class QueryOptions extends IInspectable
       _iQueryOptions.indexerOption = value;
 
   @override
-  IVector<SortEntry> get sortOrder => _iQueryOptions.sortOrder;
+  IVector<SortEntry>? get sortOrder => _iQueryOptions.sortOrder;
 
   @override
   String get groupPropertyName => _iQueryOptions.groupPropertyName;
@@ -114,6 +114,6 @@ class QueryOptions extends IInspectable
       IQueryOptionsWithProviderFilter.from(this);
 
   @override
-  IVector<String> get storageProviderIdFilter =>
+  IVector<String>? get storageProviderIdFilter =>
       _iQueryOptionsWithProviderFilter.storageProviderIdFilter;
 }

--- a/packages/windows_storage/test/collections_test.dart
+++ b/packages/windows_storage/test/collections_test.dart
@@ -21,7 +21,7 @@ void main() {
   group('IVector<String>', () {
     IVector<String> getVector() {
       final picker = FileOpenPicker();
-      return picker.fileTypeFilter;
+      return picker.fileTypeFilter!;
     }
 
     test('getAt fails if the vector is empty', () {

--- a/packages/windows_system/lib/src/folderlauncheroptions.dart
+++ b/packages/windows_system/lib/src/folderlauncheroptions.dart
@@ -33,7 +33,7 @@ class FolderLauncherOptions extends IInspectable
   late final _iFolderLauncherOptions = IFolderLauncherOptions.from(this);
 
   @override
-  IVector<IStorageItem?> get itemsToSelect =>
+  IVector<IStorageItem?>? get itemsToSelect =>
       _iFolderLauncherOptions.itemsToSelect;
 
   late final _iLauncherViewOptions = ILauncherViewOptions.from(this);

--- a/packages/windows_system/lib/src/ifolderlauncheroptions.dart
+++ b/packages/windows_system/lib/src/ifolderlauncheroptions.dart
@@ -27,7 +27,7 @@ class IFolderLauncherOptions extends IInspectable {
       IFolderLauncherOptions.fromPtr(
           interface.toInterface(IID_IFolderLauncherOptions));
 
-  IVector<IStorageItem?> get itemsToSelect {
+  IVector<IStorageItem?>? get itemsToSelect {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -45,6 +45,11 @@ class IFolderLauncherOptions extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_system/lib/src/ilaunchuriresult.dart
+++ b/packages/windows_system/lib/src/ilaunchuriresult.dart
@@ -51,7 +51,7 @@ class ILaunchUriResult extends IInspectable {
     }
   }
 
-  ValueSet get result {
+  ValueSet? get result {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -69,6 +69,11 @@ class ILaunchUriResult extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return ValueSet.fromPtr(value);

--- a/packages/windows_system/lib/src/launchuriresult.dart
+++ b/packages/windows_system/lib/src/launchuriresult.dart
@@ -28,5 +28,5 @@ class LaunchUriResult extends IInspectable implements ILaunchUriResult {
   LaunchUriStatus get status => _iLaunchUriResult.status;
 
   @override
-  ValueSet get result => _iLaunchUriResult.result;
+  ValueSet? get result => _iLaunchUriResult.result;
 }

--- a/packages/windows_ui/example/dialog.dart
+++ b/packages/windows_ui/example/dialog.dart
@@ -17,7 +17,7 @@ void main() async {
 
   // Add commands
   messageDialog.commands
-    ..append(UICommand.create('Install updates'))
+    ?..append(UICommand.create('Install updates'))
     ..append(UICommand.create("Don't install"));
 
   messageDialog

--- a/packages/windows_ui/lib/src/notifications/inotificationdata.dart
+++ b/packages/windows_ui/lib/src/notifications/inotificationdata.dart
@@ -25,7 +25,7 @@ class INotificationData extends IInspectable {
   factory INotificationData.from(IInspectable interface) =>
       INotificationData.fromPtr(interface.toInterface(IID_INotificationData));
 
-  IMap<String, String> get values {
+  IMap<String, String>? get values {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -43,6 +43,11 @@ class INotificationData extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IMap.fromPtr(value,

--- a/packages/windows_ui/lib/src/notifications/notificationdata.dart
+++ b/packages/windows_ui/lib/src/notifications/notificationdata.dart
@@ -42,7 +42,7 @@ class NotificationData extends IInspectable implements INotificationData {
   late final _iNotificationData = INotificationData.from(this);
 
   @override
-  IMap<String, String> get values => _iNotificationData.values;
+  IMap<String, String>? get values => _iNotificationData.values;
 
   @override
   int get sequenceNumber => _iNotificationData.sequenceNumber;

--- a/packages/windows_ui/lib/src/popups/imessagedialog.dart
+++ b/packages/windows_ui/lib/src/popups/imessagedialog.dart
@@ -73,7 +73,7 @@ class IMessageDialog extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  IVector<IUICommand?> get commands {
+  IVector<IUICommand?>? get commands {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -91,6 +91,11 @@ class IMessageDialog extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVector.fromPtr(value,

--- a/packages/windows_ui/lib/src/popups/messagedialog.dart
+++ b/packages/windows_ui/lib/src/popups/messagedialog.dart
@@ -44,7 +44,7 @@ class MessageDialog extends IInspectable implements IMessageDialog {
   set title(String value) => _iMessageDialog.title = value;
 
   @override
-  IVector<IUICommand?> get commands => _iMessageDialog.commands;
+  IVector<IUICommand?>? get commands => _iMessageDialog.commands;
 
   @override
   int get defaultCommandIndex => _iMessageDialog.defaultCommandIndex;

--- a/packages/winrtgen/lib/src/models/projection_kind.dart
+++ b/packages/winrtgen/lib/src/models/projection_kind.dart
@@ -97,7 +97,13 @@ enum ProjectionKind {
     if (type.isWinRTEnum) return ProjectionKind.enum_;
     if (type.isGuid) return ProjectionKind.guid;
     if (type.isAsyncAction) return ProjectionKind.asyncAction;
+    if (type.isAsyncActionWithProgress) {
+      return ProjectionKind.asyncActionWithProgress;
+    }
     if (type.isAsyncOperation) return ProjectionKind.asyncOperation;
+    if (type.isAsyncOperationWithProgress) {
+      return ProjectionKind.asyncOperationWithProgress;
+    }
     if (type.isMap) return ProjectionKind.map;
     if (type.isMapView) return ProjectionKind.mapView;
     if (type.isReference) return ProjectionKind.reference;

--- a/packages/winrtgen/lib/src/projections/parameter.dart
+++ b/packages/winrtgen/lib/src/projections/parameter.dart
@@ -43,10 +43,12 @@ abstract class ParameterProjection {
       final projectionKind = param.projectionKind;
       return switch (projectionKind) {
         ProjectionKind.asyncAction => AsyncActionParameterProjection(param),
+        ProjectionKind.asyncActionWithProgress =>
+          AsyncActionWithProgressParameterProjection(param),
         ProjectionKind.asyncOperation =>
           AsyncOperationParameterProjection(param),
-        ProjectionKind.asyncActionWithProgress ||
-        ProjectionKind.asyncOperationWithProgress ||
+        ProjectionKind.asyncOperationWithProgress =>
+          AsyncOperationWithProgressParameterProjection(param),
         ProjectionKind.dartPrimitive ||
         ProjectionKind.pointer ||
         ProjectionKind.void_ =>
@@ -103,6 +105,8 @@ abstract class ParameterProjection {
 
   /// The type of the parameter (e.g. `String`).
   String get type => typeProjection.dartType;
+
+  String get shortTypeName => typeProjection.typeIdentifier.shortName;
 
   String get creatorPreamble => '';
 

--- a/packages/winrtgen/lib/src/projections/type.dart
+++ b/packages/winrtgen/lib/src/projections/type.dart
@@ -9,9 +9,7 @@ import '../models/models.dart';
 import '../utilities/utilities.dart';
 
 final class TypeProjection {
-  TypeProjection(TypeIdentifier ti, {this.isInParam = false})
-      : typeIdentifier =
-            ti.isGenericType ? ti.copyWith(name: ti.shortName) : ti;
+  TypeProjection(this.typeIdentifier, {this.isInParam = false});
 
   final TypeIdentifier typeIdentifier;
 
@@ -45,11 +43,29 @@ final class TypeProjection {
               .any((interface) => interface.name.endsWith('IAsyncAction')) ??
           false);
 
+  bool get isAsyncActionWithProgress =>
+      typeIdentifier.name == 'Windows.Foundation.IAsyncActionWithProgress`1' ||
+      // Does the type implement IAsyncActionWithProgress?
+      (typeIdentifier.type?.interfaces.any((interface) =>
+              interface.typeSpec?.name.endsWith('IAsyncActionWithProgress`1') ??
+              false) ??
+          false);
+
   bool get isAsyncOperation =>
       (typeIdentifier.type?.name.endsWith('IAsyncOperation`1') ?? false) ||
       // Does the type implement IAsyncOperation?
       (typeIdentifier.type?.interfaces.any((interface) =>
               interface.typeSpec?.name.endsWith('IAsyncOperation`1') ??
+              false) ??
+          false);
+
+  bool get isAsyncOperationWithProgress =>
+      (typeIdentifier.type?.name.endsWith('IAsyncOperationWithProgress`2') ??
+          false) ||
+      // Does the type implement IAsyncOperationWithProgress?
+      (typeIdentifier.type?.interfaces.any((interface) =>
+              interface.typeSpec?.name
+                  .endsWith('IAsyncOperationWithProgress`2') ??
               false) ??
           false);
 
@@ -175,7 +191,7 @@ final class TypeProjection {
       throw WinRTGenException('Struct type missing for $typeIdentifier.');
     }
 
-    final structName = 'Native${structType.shortName}';
+    final structName = 'Native${lastComponent(structType.name)}';
     return TypeTuple(structName, structName);
   }
 

--- a/packages/winrtgen/lib/src/projections/types/async.dart
+++ b/packages/winrtgen/lib/src/projections/types/async.dart
@@ -26,6 +26,25 @@ final class AsyncActionParameterProjection extends ParameterProjection {
   bool get needsDeallocation => false;
 }
 
+/// Parameter projection for `IAsyncActionWithProgress` parameters.
+final class AsyncActionWithProgressParameterProjection
+    extends ParameterProjection {
+  AsyncActionWithProgressParameterProjection(super.parameter);
+
+  @override
+  String get type => 'Pointer<COMObject>';
+
+  @override
+  String get creator => identifier;
+
+  @override
+  String get into => '$identifier.ref.lpVtbl';
+
+  // No deallocation is needed as Finalizer will handle it.
+  @override
+  bool get needsDeallocation => false;
+}
+
 /// Parameter projection for `IAsyncOperation` parameters.
 final class AsyncOperationParameterProjection
     extends AsyncActionParameterProjection {
@@ -45,6 +64,7 @@ final class AsyncOperationParameterProjection
       if (interface.typeSpec case final typeSpec?) return typeSpec;
       throw WinRTGenException("Type '$interface' has no TypeSpec.");
     }
+
     return typeProjection.typeIdentifier;
   }
 
@@ -122,4 +142,23 @@ final class AsyncOperationParameterProjection
 
   @override
   String get into => '$identifier.ptr.ref.lpVtbl';
+}
+
+/// Parameter projection for `IAsyncOperationWithProgress` parameters.
+final class AsyncOperationWithProgressParameterProjection
+    extends ParameterProjection {
+  AsyncOperationWithProgressParameterProjection(super.parameter);
+
+  @override
+  String get type => 'Pointer<COMObject>';
+
+  @override
+  String get creator => identifier;
+
+  @override
+  String get into => '$identifier.ref.lpVtbl';
+
+  // No deallocation is needed as Finalizer will handle it.
+  @override
+  bool get needsDeallocation => false;
 }

--- a/packages/winrtgen/lib/src/projections/types/default.dart
+++ b/packages/winrtgen/lib/src/projections/types/default.dart
@@ -283,7 +283,6 @@ base class DefaultListParameterProjection extends ParameterProjection {
 
   // TODO(halildurmus): Remove this
   @override
-  String get localIdentifier => !isOutParam && !isInParam
-      ? identifier
-      : 'p${identifier.capitalize()}Array';
+  String get localIdentifier =>
+      isReturnParam ? identifier : 'p${identifier.capitalize()}Array';
 }

--- a/packages/winrtgen/lib/src/projections/types/enum.dart
+++ b/packages/winrtgen/lib/src/projections/types/enum.dart
@@ -2,8 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import '../../exception/exception.dart';
-import '../../utilities/utilities.dart';
 import '../parameter.dart';
 
 /// Parameter projection for WinRT enum parameters.
@@ -11,10 +9,7 @@ final class EnumParameterProjection extends ParameterProjection {
   EnumParameterProjection(super.parameter);
 
   @override
-  String get type {
-    if (parameter.typeIdentifier.type case final type?) return type.shortName;
-    throw WinRTGenException('Type ${parameter.typeIdentifier} has no TypeDef.');
-  }
+  String get type => shortTypeName;
 
   @override
   String get creator => '$type.from($identifier.value)';

--- a/packages/winrtgen/lib/src/projections/types/object.dart
+++ b/packages/winrtgen/lib/src/projections/types/object.dart
@@ -15,8 +15,6 @@ final class ObjectParameterProjection extends ParameterProjection {
 
   bool get isObjectType => typeProjection.isObjectType;
 
-  String get shortName => typeProjection.typeIdentifier.shortName;
-
   @override
   bool get isNullable {
     // TODO(halildurmus): Remove this
@@ -27,7 +25,10 @@ final class ObjectParameterProjection extends ParameterProjection {
       if (method.parent.isFactoryInterface) return false;
 
       // Methods that return collection interfaces cannot return null.
-      if (typeProjection.typeIdentifier.isCollectionObject) return false;
+      if (!method.isGetProperty &&
+          typeProjection.typeIdentifier.isCollectionObject) {
+        return false;
+      }
 
       // IIterable.First() cannot return null.
       if (method.name == 'First' && method.parent.isCollectionObject) {
@@ -37,11 +38,6 @@ final class ObjectParameterProjection extends ParameterProjection {
       //
       if (isObjectType && isMethodFromPropertyValueStatics) return false;
     }
-
-    // TODO(halildurmus): Remove this once methods that return
-    // IAsyncActionWithProgress and IAsyncOperationWithProgress delegates are
-    // supported.
-    if (shortName.startsWith('IAsync')) return false;
 
     // Treat everything else as nullable.
     return true;
@@ -59,12 +55,7 @@ final class ObjectParameterProjection extends ParameterProjection {
       return 'Object?';
     }
 
-    // TODO(halildurmus): Remove this once methods that return
-    // IAsyncActionWithProgress and IAsyncOperationWithProgress delegates are
-    // supported.
-    if (shortName.startsWith('IAsync')) return 'Pointer<COMObject>';
-
-    return isNullable ? nullable(shortName) : shortName;
+    return isNullable ? nullable(shortTypeName) : shortTypeName;
   }
 
   @override

--- a/packages/winrtgen/lib/src/projections/types/reference.dart
+++ b/packages/winrtgen/lib/src/projections/types/reference.dart
@@ -12,7 +12,7 @@ final class ReferenceParameterProjection extends ParameterProjection {
   ReferenceParameterProjection(super.parameter);
 
   @override
-  String get type => typeArguments(typeProjection.typeIdentifier.shortName);
+  String get type => typeArguments(shortTypeName);
 
   TypeProjection get typeArgProjection =>
       TypeProjection(typeProjection.typeIdentifier.typeArgs.first);
@@ -51,9 +51,8 @@ final class ReferenceParameterProjection extends ParameterProjection {
       'IReference<$type>.fromPtr($identifier$referenceConstructorArgs).value';
 
   @override
-  String get into => typeProjection.isReferenceType
-      ? '$identifier?.toReference($toReferenceArgument).ptr ?? nullptr'
-      : '$identifier?.toReference($toReferenceArgument).ptr.ref.lpVtbl ?? nullptr';
+  String get into =>
+      '$identifier?.toReference($toReferenceArgument).ptr.ref.lpVtbl ?? nullptr';
 
   // No deallocation is needed as Finalizer will handle it.
   @override

--- a/packages/winrtgen/lib/src/projections/types/struct.dart
+++ b/packages/winrtgen/lib/src/projections/types/struct.dart
@@ -2,7 +2,6 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import '../../utilities/utilities.dart';
 import '../parameter.dart';
 import 'default.dart';
 
@@ -11,8 +10,7 @@ final class StructParameterProjection extends ParameterProjection {
   StructParameterProjection(super.parameter);
 
   @override
-  String get type =>
-      typeProjection.isGuid ? 'Guid' : typeProjection.typeIdentifier.shortName;
+  String get type => shortTypeName;
 
   @override
   String get creator =>

--- a/packages/winrtgen/lib/src/utilities/extensions/base_type_helpers.dart
+++ b/packages/winrtgen/lib/src/utilities/extensions/base_type_helpers.dart
@@ -11,6 +11,7 @@ extension BaseTypeHelpers on BaseType {
   String get dartType => switch (this) {
         BaseType.booleanType => 'bool',
         BaseType.doubleType || BaseType.floatType => 'double',
+        BaseType.charType ||
         BaseType.int8Type ||
         BaseType.int16Type ||
         BaseType.int32Type ||
@@ -21,6 +22,7 @@ extension BaseTypeHelpers on BaseType {
         BaseType.uint64Type =>
           'int',
         BaseType.stringType => 'String',
+        BaseType.voidType => 'void',
         _ => throw WinRTGenException('Unsupported BaseType: $this'),
       };
 

--- a/packages/winrtgen/test/goldens/icalendar.golden
+++ b/packages/winrtgen/test/goldens/icalendar.golden
@@ -76,7 +76,7 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) throwWindowsException(hr);
   }
 
-  List<String> get languages {
+  List<String>? get languages {
     final value = calloc<COMObject>();
 
     final hr = ptr.ref.vtable
@@ -94,6 +94,11 @@ class ICalendar extends IInspectable {
     if (FAILED(hr)) {
       free(value);
       throwWindowsException(hr);
+    }
+
+    if (value.isNull) {
+      free(value);
+      return null;
     }
 
     return IVectorView<String>.fromPtr(value,

--- a/packages/winrtgen/test/projections/getter_test.dart
+++ b/packages/winrtgen/test/projections/getter_test.dart
@@ -95,8 +95,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('WwwFormUrlDecoder'));
-      expect(projection.header, equals('WwwFormUrlDecoder get queryParsed'));
+      expect(projection.returnType, equals('WwwFormUrlDecoder?'));
+      expect(projection.header, equals('WwwFormUrlDecoder? get queryParsed'));
       expect(projection.paramIdentifier, equals('ppWwwFormUrlDecoder'));
       expect(projection.preambles,
           equals(['final ppWwwFormUrlDecoder = calloc<COMObject>();']));
@@ -116,7 +116,7 @@ void main() {
           projection.failedCheck,
           equals(failedCheck(
               freeRetVal: true, identifier: 'ppWwwFormUrlDecoder')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('ppWwwFormUrlDecoder')));
       expect(projection.returnStatement,
           equals('return WwwFormUrlDecoder.fromPtr(ppWwwFormUrlDecoder);'));
       expect(projection.postambles, isEmpty);
@@ -472,8 +472,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('IMap<String, String>'));
-      expect(projection.header, equals('IMap<String, String> get values'));
+      expect(projection.returnType, equals('IMap<String, String>?'));
+      expect(projection.header, equals('IMap<String, String>? get values'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -490,7 +490,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IMap.fromPtr(value,
             iterableIid: '{e9bdaaf0-cbf6-5c72-be90-29cbf3a1319b}');
@@ -504,8 +504,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('Map<String, Object?>'));
-      expect(projection.header, equals('Map<String, Object?> get properties'));
+      expect(projection.returnType, equals('Map<String, Object?>?'));
+      expect(projection.header, equals('Map<String, Object?>? get properties'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -522,7 +522,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
             return IMapView<String, Object?>.fromPtr(value,
                 iterableIid: '{fe2f3d47-5d47-5499-8374-430c7cda0204}').toMap();
@@ -569,8 +569,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('IVector<int>'));
-      expect(projection.header, equals('IVector<int> get materialIndices'));
+      expect(projection.returnType, equals('IVector<int>?'));
+      expect(projection.header, equals('IVector<int>? get materialIndices'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -587,7 +587,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVector.fromPtr(value,
             iterableIid: '{421d4b91-b13b-5f37-ae54-b5249bd80539}',
@@ -602,8 +602,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('IVector<SortEntry>'));
-      expect(projection.header, equals('IVector<SortEntry> get sortOrder'));
+      expect(projection.returnType, equals('IVector<SortEntry>?'));
+      expect(projection.header, equals('IVector<SortEntry>? get sortOrder'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -620,7 +620,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVector.fromPtr(value,
             iterableIid: '{35aff6f9-ef75-5280-bb84-a2bf8317cf35}');
@@ -634,8 +634,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('IVector<String>'));
-      expect(projection.header, equals('IVector<String> get fileTypeFilter'));
+      expect(projection.returnType, equals('IVector<String>?'));
+      expect(projection.header, equals('IVector<String>? get fileTypeFilter'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -652,7 +652,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVector.fromPtr(value,
             iterableIid: '{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}');
@@ -666,8 +666,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('IVector<Uri?>'));
-      expect(projection.header, equals('IVector<Uri?> get serverUris'));
+      expect(projection.returnType, equals('IVector<Uri?>?'));
+      expect(projection.header, equals('IVector<Uri?>? get serverUris'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -684,7 +684,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVector.fromPtr(value,
             iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}');
@@ -698,8 +698,9 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('List<BasicGeoposition>'));
-      expect(projection.header, equals('List<BasicGeoposition> get positions'));
+      expect(projection.returnType, equals('List<BasicGeoposition>?'));
+      expect(
+          projection.header, equals('List<BasicGeoposition>? get positions'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -716,7 +717,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVectorView<BasicGeoposition>.fromPtr(value,
             iterableIid: '{922399a8-0093-5009-a8d2-f87b0eae75f5}').toList();
@@ -730,8 +731,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('List<int>'));
-      expect(projection.header, equals('List<int> get shape'));
+      expect(projection.returnType, equals('List<int>?'));
+      expect(projection.header, equals('List<int>? get shape'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -748,7 +749,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVectorView<int>.fromPtr(value,
             iterableIid: '{7784427e-f9cc-518d-964b-e50d5ce727f1}',
@@ -764,8 +765,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('List<Object?>'));
-      expect(projection.header, equals('List<Object?> get items'));
+      expect(projection.returnType, equals('List<Object?>?'));
+      expect(projection.header, equals('List<Object?>? get items'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -782,7 +783,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVectorView<Object?>.fromPtr(value,
             iterableIid: '{092b849b-60b1-52be-a44a-6fe8e933cbe4}').toList();
@@ -796,8 +797,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('List<String>'));
-      expect(projection.header, equals('List<String> get languages'));
+      expect(projection.returnType, equals('List<String>?'));
+      expect(projection.header, equals('List<String>? get languages'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -814,7 +815,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVectorView<String>.fromPtr(value,
             iterableIid: '{e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e}').toList();
@@ -828,8 +829,8 @@ void main() {
       expect(projection, isA<DefaultGetterProjection>());
       expect(projection.annotations, isEmpty);
       expect(projection.useTryFinallyBlock, isFalse);
-      expect(projection.returnType, equals('List<Uri?>'));
-      expect(projection.header, equals('List<Uri?> get updateUris'));
+      expect(projection.returnType, equals('List<Uri?>?'));
+      expect(projection.header, equals('List<Uri?>? get updateUris'));
       expect(projection.paramIdentifier, equals('value'));
       expect(
           projection.preambles, equals(['final value = calloc<COMObject>();']));
@@ -846,7 +847,7 @@ void main() {
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('value')));
       expect(projection.returnStatement, equalsIgnoringWhitespace('''
         return IVectorView<Uri?>.fromPtr(value,
             iterableIid: '{b0d63b78-78ad-5e31-b6d8-e32a0e16c447}').toList();

--- a/packages/winrtgen/test/projections/method_test.dart
+++ b/packages/winrtgen/test/projections/method_test.dart
@@ -762,10 +762,8 @@ void main() {
           projection.dartPrototype,
           equals(
               'int Function(VTablePointer lpVtbl, VTablePointer file, Pointer<COMObject> result)'));
-      expect(
-          projection.identifiers,
-          equals(
-              'ptr.ref.lpVtbl, file?.ptr.ref.lpVtbl ?? nullptr, result'));
+      expect(projection.identifiers,
+          equals('ptr.ref.lpVtbl, file?.ptr.ref.lpVtbl ?? nullptr, result'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'result')));
@@ -1065,10 +1063,8 @@ void main() {
           projection.dartPrototype,
           equals(
               'int Function(VTablePointer lpVtbl, VTablePointer user, Pointer<COMObject> value)'));
-      expect(
-          projection.identifiers,
-          equals(
-              'ptr.ref.lpVtbl, user?.ptr.ref.lpVtbl ?? nullptr, value'));
+      expect(projection.identifiers,
+          equals('ptr.ref.lpVtbl, user?.ptr.ref.lpVtbl ?? nullptr, value'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck,
           equals(failedCheck(freeRetVal: true, identifier: 'value')));

--- a/packages/winrtgen/test/projections/parameter_test.dart
+++ b/packages/winrtgen/test/projections/parameter_test.dart
@@ -421,7 +421,7 @@ void main() {
       expect(projection.toListIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.postambles, isEmpty);
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('features')));
       expect(projection.identifier, equals('features'));
       expect(projection.localIdentifier,
           equals('features?.ptr.ref.lpVtbl ?? nullptr'));
@@ -549,7 +549,7 @@ void main() {
       expect(projection.toListIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.postambles, isEmpty);
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('dnsServerList')));
       expect(projection.identifier, equals('dnsServerList'));
       expect(projection.localIdentifier,
           equals('dnsServerList?.ptr.ref.lpVtbl ?? nullptr'));
@@ -578,7 +578,7 @@ void main() {
       expect(projection.toListIdentifier, isEmpty);
       expect(projection.preambles, isEmpty);
       expect(projection.postambles, isEmpty);
-      expect(projection.nullCheck, isEmpty);
+      expect(projection.nullCheck, equals(nullCheck('values')));
       expect(projection.identifier, equals('values'));
       expect(projection.localIdentifier,
           equals('values?.ptr.ref.lpVtbl ?? nullptr'));

--- a/packages/winrtgen/test/projections/setter_test.dart
+++ b/packages/winrtgen/test/projections/setter_test.dart
@@ -88,10 +88,8 @@ void main() {
               'HRESULT Function(VTablePointer lpVtbl, VTablePointer value)'));
       expect(projection.dartPrototype,
           equals('int Function(VTablePointer lpVtbl, VTablePointer value)'));
-      expect(
-          projection.identifiers,
-          equals(
-              'ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
+      expect(projection.identifiers,
+          equals('ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);
@@ -312,10 +310,8 @@ void main() {
               'HRESULT Function(VTablePointer lpVtbl, VTablePointer value)'));
       expect(projection.dartPrototype,
           equals('int Function(VTablePointer lpVtbl, VTablePointer value)'));
-      expect(
-          projection.identifiers,
-          equals(
-              'ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
+      expect(projection.identifiers,
+          equals('ptr.ref.lpVtbl, value?.ptr.ref.lpVtbl ?? nullptr'));
       expect(projection.parametersPostamble, isEmpty);
       expect(projection.failedCheck, equals(failedCheck()));
       expect(projection.nullCheck, isEmpty);

--- a/packages/winrtgen/test/utilities/extensions/type_identifier_helpers_test.dart
+++ b/packages/winrtgen/test/utilities/extensions/type_identifier_helpers_test.dart
@@ -307,7 +307,7 @@ void main() {
               .last
               .typeIdentifier
               .shortName,
-          equals('Object'));
+          equals('Object?'));
     });
 
     test('(7)', () {


### PR DESCRIPTION
<!-- Thanks for contributing! -->

## Description

Getters that return collection objects such as `IVector` are now nullable.

## Related Issue

Fixes #296 

## Type of Change

<!---
  Please look at the following checklist and put an `x` in all the boxes that
  apply to ensure that your PR can be accepted quickly:
-->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🧪 `test` -- Test
- [ ] 🗑️ `chore` -- Chore
